### PR TITLE
[Phase 7] 게임 재시작 로직 구현 (#46)

### DIFF
--- a/frontend/ACCEPTANCE_CRITERIA_46.md
+++ b/frontend/ACCEPTANCE_CRITERIA_46.md
@@ -1,0 +1,389 @@
+# Acceptance Criteria - Issue #46
+
+## 📋 Issue
+**[Phase 7] 게임 재시작 로직 구현**
+
+## ✅ Acceptance Criteria Checklist
+
+### 1. handleRestart 함수가 작성되었는가?
+- ✅ **충족**
+- **검증 방법**:
+  - `App.tsx:189-228` - `handleRestart` async 함수 구현
+  ```typescript
+  const handleRestart = async () => {
+    // 1. RESET_GAME 액션
+    // 2. SET_LOADING
+    // 3. startGame() API 호출
+    // 4. INIT_GAME 액션
+  }
+  ```
+
+### 2. "게임 재시작" 버튼 클릭 시 API가 호출되는가?
+- ✅ **충족**
+- **검증 방법**:
+  - `handleRestart` 내부에서 `await startGame()` 호출
+  - ResultModal의 RestartButton onClick에 handleRestart 연결
+  ```typescript
+  const { gameId, cards } = await startGame()
+  ```
+
+### 3. 상태가 초기화되는가 (life=3, status='PLAYING')?
+- ✅ **충족**
+- **검증 방법**:
+  - `RESET_GAME` 액션: initialState로 완전 초기화
+  - `INIT_GAME` 액션: life=3, status='PLAYING' 설정
+  ```typescript
+  dispatch({ type: 'RESET_GAME' })
+  // → initialState (life: 3, status: 'IDLE')
+
+  dispatch({ type: 'INIT_GAME', payload: { gameId, cards } })
+  // → life: 3, status: 'PLAYING'
+  ```
+
+### 4. 카드가 새롭게 셔플되어 배치되는가?
+- ✅ **충족**
+- **검증 방법**:
+  - `/api/game/start` API 호출로 새로운 카드 배열 받기
+  - 서버에서 매번 랜덤하게 셔플된 16개 카드 반환
+  - 이전 게임과 다른 배치로 게임 시작
+
+### 5. 모달이 닫히는가?
+- ✅ **충족**
+- **검증 방법**:
+  - `RESET_GAME` → status = 'IDLE'
+  - `INIT_GAME` → status = 'PLAYING'
+  - ResultModal의 isOpen 조건:
+    ```typescript
+    isOpen={state.status === 'VICTORY' || state.status === 'GAME_OVER'}
+    ```
+  - status가 'PLAYING'이 되면 모달 자동으로 닫힘
+
+## 📝 구현 세부사항
+
+### 변경 파일 1: App.tsx
+
+#### 1. Import 추가 (8, 12줄)
+```typescript
+import { ResultModal } from './components/ResultModal'
+import { startGame } from './api/gameApi'
+```
+
+#### 2. handleRestart 함수 (189-228줄)
+```typescript
+const handleRestart = async () => {
+  console.log('[Game Restart] Restarting game...')
+
+  try {
+    // 1. 상태 초기화 (모달이 닫히고 상태가 IDLE로 변경됨)
+    dispatch({ type: 'RESET_GAME' })
+
+    // 2. 로딩 시작
+    dispatch({ type: 'SET_LOADING', payload: true })
+
+    // 3. API 호출로 새로운 게임 데이터 받기
+    const { gameId, cards } = await startGame()
+
+    // 4. 새 게임 초기화
+    dispatch({
+      type: 'INIT_GAME',
+      payload: { gameId, cards },
+    })
+
+    console.log(`[Game Restart] New game started: ${gameId}`)
+  } catch (error) {
+    // 에러 처리
+    const errorMessage =
+      error instanceof Error ? error.message : '게임 재시작에 실패했습니다'
+
+    dispatch({
+      type: 'SET_ERROR',
+      payload: errorMessage,
+    })
+
+    alert(`게임 재시작 실패\n\n${errorMessage}`)
+    console.error('[Game Restart Error]', error)
+  }
+}
+```
+
+**단계별 설명**
+1. **RESET_GAME**: 상태를 initialState로 초기화
+   - gameId: null
+   - cards: []
+   - flippedCards: []
+   - life: 3
+   - status: 'IDLE'
+   - isLoading: false
+   - error: null
+   - isMatching: false
+
+2. **SET_LOADING**: 로딩 상태 활성화
+   - isLoading: true
+   - Loading... 메시지 표시
+
+3. **startGame() API 호출**: 새로운 게임 데이터 받기
+   - 서버에서 새로운 gameId 생성
+   - 16개의 카드를 랜덤 셔플하여 반환
+
+4. **INIT_GAME**: 새 게임으로 초기화
+   - gameId, cards 설정
+   - life: 3
+   - status: 'PLAYING'
+   - isLoading: false
+
+#### 3. ResultModal 렌더링 (252-260줄)
+```typescript
+// 게임 플레이 화면
+return (
+  <>
+    <GameContainer>
+      <Header life={state.life} />
+      <GameBoard cards={state.cards} onCardClick={handleCardClick} />
+    </GameContainer>
+    {/* 결과 모달 (VICTORY 또는 GAME_OVER 시 표시) */}
+    <ResultModal
+      isOpen={state.status === 'VICTORY' || state.status === 'GAME_OVER'}
+      result={state.status as 'VICTORY' | 'GAME_OVER'}
+      onRestart={handleRestart}
+    />
+  </>
+)
+```
+
+**Fragment (빈 태그) 사용 이유**
+```typescript
+// ❌ 에러: return에는 하나의 루트 요소만 가능
+return (
+  <GameContainer>...</GameContainer>
+  <ResultModal ... />
+)
+
+// ✅ Fragment로 감싸기
+return (
+  <>
+    <GameContainer>...</GameContainer>
+    <ResultModal ... />
+  </>
+)
+```
+
+### 신규 파일 2: components/ResultModal.tsx
+- Issue #45에서 생성된 컴포넌트
+- 이 브랜치에서도 포함하여 독립적으로 작동하도록 함
+- PR merge 후 중복 제거됨
+
+## 🎓 소프트웨어 공학적 설계 원칙
+
+### 1. 게임 재시작 흐름
+
+```
+[사용자] "게임 재시작" 버튼 클릭
+    ↓
+[handleRestart] RESET_GAME 디스패치
+    ↓
+[Reducer] initialState로 초기화
+    ↓ status = 'IDLE' → 모달 닫힘
+[handleRestart] SET_LOADING(true) 디스패치
+    ↓
+[UI] "Loading..." 표시
+    ↓
+[handleRestart] startGame() API 호출
+    ↓
+[API] 새로운 gameId, 셔플된 cards 반환
+    ↓
+[handleRestart] INIT_GAME 디스패치
+    ↓
+[Reducer] life=3, status='PLAYING', cards 설정
+    ↓
+[UI] 새 게임 시작
+```
+
+### 2. 상태 초기화 전략
+
+#### RESET_GAME vs 수동 초기화
+```typescript
+// ❌ 수동 초기화 (비추천)
+dispatch({ type: 'SET_LIFE', payload: 3 })
+dispatch({ type: 'SET_STATUS', payload: 'IDLE' })
+dispatch({ type: 'SET_CARDS', payload: [] })
+// ... 많은 액션 필요
+
+// ✅ RESET_GAME (권장)
+dispatch({ type: 'RESET_GAME' })
+// 하나의 액션으로 모든 상태 초기화
+```
+
+**장점**
+- 한 번의 액션으로 완전 초기화
+- 상태 누락 위험 없음
+- 코드 간결성
+
+### 3. 에러 처리
+
+#### try-catch로 안전한 API 호출
+```typescript
+try {
+  const { gameId, cards } = await startGame()
+  // 성공 시 게임 초기화
+} catch (error) {
+  // 실패 시 에러 처리
+  dispatch({ type: 'SET_ERROR', payload: errorMessage })
+  alert(`게임 재시작 실패\n\n${errorMessage}`)
+}
+```
+
+**에러 시나리오**
+- 네트워크 오류
+- 서버 다운
+- 타임아웃
+
+**처리 방법**
+1. SET_ERROR로 에러 상태 저장
+2. alert로 사용자에게 즉시 알림
+3. console.error로 디버깅 정보 로깅
+
+### 4. 사용자 경험 (UX)
+
+#### Retention (재미) 향상
+- **즉시 재시작**: 버튼 하나로 새 게임 시작
+- **깜빡임 없음**: 로딩 중 "Loading..." 표시
+- **새로운 배치**: 매번 다른 카드 배치로 신선함 유지
+
+#### 피드백 제공
+```
+1. 버튼 클릭 → 모달 닫힘 (즉각 반응)
+2. "Loading..." 표시 (진행 상황 알림)
+3. 새 게임 시작 (완료 피드백)
+```
+
+### 5. 의존성 관리
+
+#### startGame() 재사용
+```typescript
+// useGameInitializer.ts에서도 사용
+await startGame()
+
+// App.tsx (handleRestart)에서도 사용
+await startGame()
+```
+
+**DRY 원칙**
+- API 호출 로직을 `api/gameApi.ts`에 중앙 집중
+- 여러 곳에서 재사용 가능
+- 수정 시 한 곳만 변경
+
+## 🧪 테스트 시나리오
+
+### 시나리오 1: 승리 후 재시작
+```
+1. 모든 카드 매칭 완료
+2. status = 'VICTORY'
+3. ResultModal 표시 (🎉 승리!)
+4. "게임 재시작" 버튼 클릭
+5. handleRestart 실행:
+   - RESET_GAME → 모달 닫힘
+   - SET_LOADING → "Loading..."
+   - startGame() → 새 게임 데이터
+   - INIT_GAME → 새 게임 시작
+6. 새로운 카드 배치로 게임 진행
+```
+
+### 시나리오 2: 게임 오버 후 재시작
+```
+1. life = 0
+2. status = 'GAME_OVER'
+3. ResultModal 표시 (😢 게임 오버)
+4. "게임 재시작" 버튼 클릭
+5. handleRestart 실행 (동일 프로세스)
+6. life = 3으로 새 게임 시작
+```
+
+### 시나리오 3: 재시작 중 에러
+```
+1. "게임 재시작" 버튼 클릭
+2. RESET_GAME → 모달 닫힘
+3. startGame() API 호출 실패 (네트워크 오류)
+4. catch 블록 실행:
+   - SET_ERROR
+   - alert 표시
+   - console.error 로깅
+5. 에러 화면 표시
+```
+
+## 🧪 테스트 결과
+
+### TypeScript 컴파일
+```
+✓ 컴파일 성공 (에러 없음)
+```
+
+### Production 빌드
+```
+vite v7.3.1 building client environment for production...
+transforming...
+✓ 101 modules transformed.
+rendering chunks...
+computing gzip size...
+dist/index.html                   0.46 kB │ gzip:  0.29 kB
+dist/assets/index-DQ3P1g1z.css    0.91 kB │ gzip:  0.49 kB
+dist/assets/index-jTStLv1D.js   275.46 kB │ gzip: 91.40 kB
+✓ built in 391ms
+```
+
+## 📊 코드 품질 지표
+
+### 타입 안전성
+- ✅ handleRestart는 async 함수로 명시
+- ✅ error 타입 체크 (instanceof Error)
+- ✅ ResultModal props 타입 검증
+
+### 에러 처리
+- ✅ try-catch로 API 오류 처리
+- ✅ 사용자에게 alert 알림
+- ✅ console.error로 디버깅 지원
+
+### 재사용성
+- ✅ startGame() API 함수 재사용
+- ✅ RESET_GAME 액션 재사용
+- ✅ ResultModal 컴포넌트 재사용
+
+### 사용자 경험
+- ✅ 로딩 중 피드백 제공
+- ✅ 에러 시 명확한 메시지
+- ✅ 즉시 반응하는 UI
+
+## 🎯 완성된 게임 흐름
+
+```
+게임 시작
+    ↓
+카드 뒤집기 (매칭 시도)
+    ↓
+    ├─ 모든 카드 매칭 → VICTORY → 모달 표시
+    └─ Life 0 → GAME_OVER → 모달 표시
+              ↓
+       "게임 재시작" 버튼 클릭
+              ↓
+       새 게임 시작 (새로운 카드 배치)
+              ↓
+       반복적으로 즐기기 (Retention ↑)
+```
+
+## 🔗 관련 컴포넌트
+
+### 상호작용하는 컴포넌트들
+```
+App.tsx
+  ├─ useGameInitializer (게임 초기화)
+  ├─ handleCardClick (카드 클릭)
+  ├─ handleRestart (게임 재시작)
+  ├─ Header (Life 표시)
+  ├─ GameBoard (카드 보드)
+  └─ ResultModal (결과 모달)
+       └─ RestartButton → handleRestart 호출
+```
+
+---
+
+**검증 완료**: 2026-01-31
+**검증자**: Claude Sonnet 4.5

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,9 +5,11 @@ import { GlobalStyle } from './styles/GlobalStyle'
 import theme from './styles/theme'
 import { Header } from './components/Header'
 import { GameBoard } from './components/GameBoard'
+import { ResultModal } from './components/ResultModal'
 import { GameProvider } from './contexts/GameContext'
 import { useGameContext } from './contexts/GameContext'
 import { useGameInitializer } from './hooks/useGameInitializer'
+import { startGame } from './api/gameApi'
 
 /**
  * App Container
@@ -182,6 +184,48 @@ function Game() {
     }
   }, [state.flippedCards, dispatch])
 
+  /**
+   * 게임 재시작 핸들러
+   *
+   * 1. RESET_GAME 액션으로 상태 초기화
+   * 2. API 호출로 새로운 게임 시작
+   * 3. INIT_GAME 액션으로 새 게임 데이터 설정
+   */
+  const handleRestart = async () => {
+    console.log('[Game Restart] Restarting game...')
+
+    try {
+      // 1. 상태 초기화 (모달이 닫히고 상태가 IDLE로 변경됨)
+      dispatch({ type: 'RESET_GAME' })
+
+      // 2. 로딩 시작
+      dispatch({ type: 'SET_LOADING', payload: true })
+
+      // 3. API 호출로 새로운 게임 데이터 받기
+      const { gameId, cards } = await startGame()
+
+      // 4. 새 게임 초기화
+      dispatch({
+        type: 'INIT_GAME',
+        payload: { gameId, cards },
+      })
+
+      console.log(`[Game Restart] New game started: ${gameId}`)
+    } catch (error) {
+      // 에러 처리
+      const errorMessage =
+        error instanceof Error ? error.message : '게임 재시작에 실패했습니다'
+
+      dispatch({
+        type: 'SET_ERROR',
+        payload: errorMessage,
+      })
+
+      alert(`게임 재시작 실패\n\n${errorMessage}`)
+      console.error('[Game Restart Error]', error)
+    }
+  }
+
   // 로딩 중일 때
   if (state.isLoading) {
     return (
@@ -205,10 +249,18 @@ function Game() {
 
   // 게임 플레이 화면
   return (
-    <GameContainer>
-      <Header life={state.life} />
-      <GameBoard cards={state.cards} onCardClick={handleCardClick} />
-    </GameContainer>
+    <>
+      <GameContainer>
+        <Header life={state.life} />
+        <GameBoard cards={state.cards} onCardClick={handleCardClick} />
+      </GameContainer>
+      {/* 결과 모달 (VICTORY 또는 GAME_OVER 시 표시) */}
+      <ResultModal
+        isOpen={state.status === 'VICTORY' || state.status === 'GAME_OVER'}
+        result={state.status as 'VICTORY' | 'GAME_OVER'}
+        onRestart={handleRestart}
+      />
+    </>
   )
 }
 

--- a/frontend/src/components/ResultModal.tsx
+++ b/frontend/src/components/ResultModal.tsx
@@ -1,0 +1,184 @@
+import styled from 'styled-components'
+
+/**
+ * ResultModal Props Interface
+ */
+interface ResultModalProps {
+  /** 모달 표시 여부 */
+  isOpen: boolean
+  /** 게임 결과 (GAME_OVER | VICTORY) */
+  result: 'GAME_OVER' | 'VICTORY'
+  /** 게임 재시작 핸들러 */
+  onRestart: () => void
+}
+
+/**
+ * Modal Overlay
+ * 화면 전체를 덮는 반투명 배경
+ */
+const ModalOverlay = styled.div<{ $isOpen: boolean }>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${({ theme }) => theme.colors.overlay}; /* rgba(0,0,0,0.7) */
+  display: ${({ $isOpen }) => ($isOpen ? 'flex' : 'none')};
+  justify-content: center;
+  align-items: center;
+  z-index: ${({ theme }) => theme.zIndex.modal}; /* 100 */
+  animation: fadeIn ${({ theme }) => theme.transitions.normal};
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`
+
+/**
+ * Modal Content
+ * 모달의 실제 내용을 담는 컨테이너
+ */
+const ModalContent = styled.div`
+  background-color: ${({ theme }) => theme.colors.cardFront}; /* 흰색 */
+  border-radius: ${({ theme }) => theme.borderRadius.xl}; /* 16px */
+  padding: ${({ theme }) => theme.spacing.xxl}; /* 48px */
+  box-shadow: ${({ theme }) => theme.shadows.xl};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing.lg}; /* 24px */
+  min-width: 400px;
+  animation: slideUp ${({ theme }) => theme.transitions.normal};
+
+  @keyframes slideUp {
+    from {
+      transform: translateY(30px);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+
+  /* 반응형: 모바일 */
+  @media (max-width: ${({ theme }) => theme.breakpoints.mobile}) {
+    min-width: 90%;
+    padding: ${({ theme }) => theme.spacing.xl};
+  }
+`
+
+/**
+ * Modal Emoji
+ * 결과에 따른 큰 emoji 표시
+ */
+const ModalEmoji = styled.div`
+  font-size: 72px;
+  line-height: 1;
+  user-select: none;
+`
+
+/**
+ * Modal Title
+ * 모달 제목
+ */
+const ModalTitle = styled.h2<{ $result: 'GAME_OVER' | 'VICTORY' }>`
+  font-size: ${({ theme }) => theme.fontSizes.xxxl}; /* 32px */
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+  color: ${({ theme, $result }) =>
+    $result === 'VICTORY' ? theme.colors.success : theme.colors.danger};
+  margin: 0;
+  text-align: center;
+`
+
+/**
+ * Modal Message
+ * 결과 메시지
+ */
+const ModalMessage = styled.p`
+  font-size: ${({ theme }) => theme.fontSizes.lg}; /* 18px */
+  color: ${({ theme }) => theme.colors.textSecondary};
+  margin: 0;
+  text-align: center;
+  line-height: 1.6;
+`
+
+/**
+ * Restart Button
+ * 게임 재시작 버튼
+ */
+const RestartButton = styled.button`
+  background-color: ${({ theme }) => theme.colors.primary};
+  color: ${({ theme }) => theme.colors.textLight};
+  font-size: ${({ theme }) => theme.fontSizes.lg};
+  font-weight: ${({ theme }) => theme.fontWeights.semibold};
+  padding: ${({ theme }) => theme.spacing.md} ${({ theme }) => theme.spacing.xl};
+  border: none;
+  border-radius: ${({ theme }) => theme.borderRadius.md};
+  cursor: pointer;
+  transition: all ${({ theme }) => theme.transitions.fast};
+  box-shadow: ${({ theme }) => theme.shadows.md};
+  margin-top: ${({ theme }) => theme.spacing.md};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.primaryHover};
+    transform: translateY(-2px);
+    box-shadow: ${({ theme }) => theme.shadows.lg};
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+`
+
+/**
+ * ResultModal Component
+ * 게임 결과(승리/패배)를 표시하는 모달 컴포넌트
+ *
+ * @param {boolean} isOpen - 모달 표시 여부
+ * @param {'GAME_OVER' | 'VICTORY'} result - 게임 결과
+ * @param {Function} onRestart - 게임 재시작 핸들러
+ * @returns {JSX.Element} ResultModal 컴포넌트
+ *
+ * @example
+ * <ResultModal
+ *   isOpen={state.status === 'VICTORY' || state.status === 'GAME_OVER'}
+ *   result={state.status}
+ *   onRestart={handleRestart}
+ * />
+ */
+export const ResultModal: React.FC<ResultModalProps> = ({
+  isOpen,
+  result,
+  onRestart,
+}) => {
+  // result에 따른 emoji 선택
+  const emoji = result === 'VICTORY' ? '🎉' : '😢'
+
+  // result에 따른 제목 선택
+  const title = result === 'VICTORY' ? '승리!' : '게임 오버'
+
+  // result에 따른 메시지 선택
+  const message =
+    result === 'VICTORY'
+      ? '축하합니다! 모든 짝을 찾았습니다!'
+      : '아쉽네요. 다시 도전해보세요!'
+
+  return (
+    <ModalOverlay $isOpen={isOpen}>
+      <ModalContent>
+        <ModalEmoji>{emoji}</ModalEmoji>
+        <ModalTitle $result={result}>{title}</ModalTitle>
+        <ModalMessage>{message}</ModalMessage>
+        <RestartButton onClick={onRestart}>게임 재시작</RestartButton>
+      </ModalContent>
+    </ModalOverlay>
+  )
+}
+
+export default ResultModal


### PR DESCRIPTION
## 📋 Issue
Closes #46

## 🎯 구현 내용

### handleRestart 함수 구현
- RESET_GAME → SET_LOADING → startGame() → INIT_GAME 순서로 상태 초기화
- 에러 처리 및 사용자 피드백 제공
- 새로운 게임 데이터로 완전 초기화 (life=3, status='PLAYING')

### ResultModal 통합
- 승리/게임오버 시 모달 표시
- "게임 재시작" 버튼 클릭 시 handleRestart 호출
- Fragment (<>) 사용하여 다중 루트 요소 렌더링

## ✅ Acceptance Criteria

- [x] handleRestart 함수가 작성되었는가?
- [x] "게임 재시작" 버튼 클릭 시 API가 호출되는가?
- [x] 상태가 초기화되는가 (life=3, status='PLAYING')?
- [x] 카드가 새롭게 셔플되어 배치되는가?
- [x] 모달이 닫히는가?

## 🧪 테스트 결과

### TypeScript 컴파일
```
✓ 컴파일 성공 (에러 없음)
```

### Production 빌드
```
✓ built in 391ms
dist/assets/index-jTStLv1D.js   275.46 kB │ gzip: 91.40 kB
```

## 📝 변경 파일

- `frontend/src/App.tsx`: handleRestart 함수 추가, ResultModal 통합
- `frontend/src/components/ResultModal.tsx`: 결과 모달 컴포넌트 (Issue #45 포함)
- `frontend/ACCEPTANCE_CRITERIA_46.md`: 검증 문서

## 🎓 소프트웨어 공학적 설계

### 상태 초기화 전략
- RESET_GAME 액션 하나로 모든 상태 초기화 (DRY 원칙)
- 상태 누락 위험 제거

### 에러 처리
- try-catch로 네트워크 오류 대응
- SET_ERROR 액션 + alert로 사용자 알림
- console.error로 디버깅 지원

### UX 개선
- 즉시 재시작으로 User Retention 향상
- 로딩 중 피드백 제공
- 매번 다른 카드 배치로 신선함 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)