### PR TITLE
[Phase 7] UI 개선: 카드 크기 확대 및 가시성 향상

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,7 +30,7 @@ const AppContainer = styled.div`
  */
 const GameContainer = styled.div`
   width: 100%;
-  max-width: 700px; /* 최대 크기 제한 */
+  max-width: 900px; /* 최대 크기 확대 (700px → 900px) */
   aspect-ratio: 1; /* 정사각형 유지 */
   background-color: ${({ theme }) => theme.colors.cardFront};
   border-radius: ${({ theme }) => theme.borderRadius.lg};

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -20,6 +20,8 @@ interface CardProps {
 const CardContainer = styled.div`
   width: 100%; /* 부모 GridCell에 100% 맞춤 */
   height: 100%; /* 높이도 100% 맞춤 */
+  min-width: 100px; /* 최소 크기 보장 */
+  min-height: 100px; /* 최소 크기 보장 */
   cursor: pointer;
   position: relative;
   perspective: 1000px; /* 3D 효과를 위한 perspective */
@@ -81,7 +83,7 @@ const CardFront = styled(CardFace)`
  * 카드 크기에 비례하여 반응형으로 조절
  */
 const CardEmoji = styled.div`
-  font-size: clamp(40px, 8vw, 64px); /* 반응형 emoji 크기 */
+  font-size: clamp(48px, 6vw, 72px); /* 반응형 emoji 크기 (더 크게) */
   user-select: none; /* 드래그 방지 */
   line-height: 1;
 `

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -25,7 +25,7 @@ const BoardContainer = styled.div<{ $isMatching: boolean }>`
   grid-template-columns: repeat(4, 1fr); /* 4열 고정 */
   grid-template-rows: repeat(4, 1fr); /* 4행 고정 (균등 배분) */
   gap: ${({ theme }) => theme.spacing.sm}; /* 10px */
-  padding: ${({ theme }) => theme.spacing.md}; /* 16px (lg에서 md로 축소) */
+  padding: ${({ theme }) => theme.spacing.sm}; /* 10px (md에서 sm으로 축소하여 카드 공간 확보) */
   background-color: ${({ theme }) => theme.colors.background};
   pointer-events: ${({ $isMatching }) =>
     $isMatching ? 'none' : 'auto'}; /* 매칭 판별 중에는 클릭 차단 */


### PR DESCRIPTION
## 📋 Issue
Closes #78

## 🐛 문제

1. **카드가 너무 작음** - 16개 카드가 화면에 표시되지만 크기가 너무 작아서 보기 어려움
2. **emoji가 작음** - 과일 emoji가 작아서 식별하기 어려움
3. **게임 영역이 작음** - 전체 게임 컨테이너가 작아서 답답함

## ✅ 해결 방법

### 1. Card 크기 보장 (`Card.tsx`)

```typescript
// ✅ 추가
const CardContainer = styled.div`
  width: 100%;
  height: 100%;
  min-width: 100px;  // 최소 크기 보장
  min-height: 100px; // 최소 크기 보장
  ...
`
```

**효과:**
- 카드가 최소 100px × 100px 크기 유지
- 작은 화면에서도 충분한 크기

### 2. Emoji 크기 확대 (`Card.tsx`)

```typescript
// ❌ Before
font-size: clamp(40px, 8vw, 64px);

// ✅ After
font-size: clamp(48px, 6vw, 72px);  // 더 크게
```

**효과:**
- 최소 48px, 최대 72px로 확대
- 과일 emoji가 더 선명하게 보임

### 3. 게임 컨테이너 확대 (`App.tsx`)

```typescript
// ❌ Before
max-width: 700px;

// ✅ After
max-width: 900px;  // 200px 확대
```

**효과:**
- 전체 게임 영역이 더 넓어짐
- 카드를 위한 공간 증가

### 4. GameBoard padding 축소 (`GameBoard.tsx`)

```typescript
// ❌ Before
padding: ${({ theme }) => theme.spacing.md};  // 16px

// ✅ After
padding: ${({ theme }) => theme.spacing.sm};  // 10px
```

**효과:**
- padding 축소로 카드를 위한 공간 6px 추가 (양쪽 12px)
- 더 많은 공간을 카드에 할당

## 🎯 결과

### ✅ Acceptance Criteria 충족

1. **카드 크기**
   - ✅ 최소 100px × 100px 크기 보장
   - ✅ 클릭하기 쉬운 크기
   - ✅ emoji가 선명하게 보임

2. **게임 영역**
   - ✅ 900px까지 확대 가능
   - ✅ 16개 카드 모두 명확하게 표시
   - ✅ 답답하지 않은 레이아웃

3. **사용자 경험**
   - ✅ 카드 식별이 쉬워짐
   - ✅ 게임 플레이가 더 편안함
   - ✅ 반응형은 여전히 유지

## 📊 변경 사항 비교

| 항목 | Before | After | 변화 |
|------|--------|-------|------|
| GameContainer max-width | 700px | 900px | +200px |
| Card min-width/height | 없음 | 100px | 신규 |
| CardEmoji min | 40px | 48px | +8px |
| CardEmoji max | 64px | 72px | +8px |
| GameBoard padding | 16px | 10px | -6px |

## 🧪 테스트

### TypeScript 컴파일
```
✓ 컴파일 성공 (에러 없음)
```

### Production 빌드
```
✓ built in 392ms
dist/assets/index-BpNwf_rl.js   276.79 kB │ gzip: 92.17 kB
```

### 수동 테스트
- ✅ 카드가 명확하게 보임
- ✅ emoji가 선명함
- ✅ 클릭하기 쉬움
- ✅ 16개 카드 모두 표시
- ✅ 반응형 정상 작동

## 📝 변경 파일

- `frontend/src/components/Card.tsx`: min-width/height 추가, emoji 크기 확대
- `frontend/src/App.tsx`: GameContainer max-width 확대
- `frontend/src/components/GameBoard.tsx`: padding 축소

## 🔗 Related

- **Closes**: #78
- **Related to**: #72 (반응형 레이아웃)
- **Part of**: Phase 7 (Polish)

## 💡 참고사항

**재시작 버튼 이슈:**
- Issue #78에서 재시작 버튼도 언급되었으나, 이미 Issue #74에서 해결됨
- ResultModal은 현재 main 브랜치에 통합되어 정상 작동 중
- 이 PR은 카드 크기/가시성 개선에만 집중

🤖 Generated with [Claude Code](https://claude.com/claude-code)