### PR TITLE
fix: 백엔드 테스트 경로 수정, 커버리지 임계값 설정 및 CI 연동 (#84)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run tests (Jest + Supertest)
+        run: npm test
+
       - name: Build
         run: npm run build

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -14,4 +14,12 @@ module.exports = {
     'node_modules/(?!(uuid)/)',
   ],
   setupFiles: ['<rootDir>/jest.setup.js'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
 };

--- a/backend/src/__tests__/gameApi.test.ts
+++ b/backend/src/__tests__/gameApi.test.ts
@@ -1,28 +1,37 @@
 import request from 'supertest';
 import app from '../server';
 
-describe('GET /game/start', () => {
+describe('GET /health', () => {
+  test('should return 200 with status ok', async () => {
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ status: 'ok' });
+  });
+});
+
+describe('GET /api/game/start', () => {
   test('should return 200 status code', async () => {
-    const response = await request(app).get('/game/start');
+    const response = await request(app).get('/api/game/start');
 
     expect(response.status).toBe(200);
   });
 
   test('should return gameId and cards in response body', async () => {
-    const response = await request(app).get('/game/start');
+    const response = await request(app).get('/api/game/start');
 
     expect(response.body).toHaveProperty('gameId');
     expect(response.body).toHaveProperty('cards');
   });
 
   test('should return 16 cards', async () => {
-    const response = await request(app).get('/game/start');
+    const response = await request(app).get('/api/game/start');
 
     expect(response.body.cards).toHaveLength(16);
   });
 
   test('each card should have id, type, and imgUrl', async () => {
-    const response = await request(app).get('/game/start');
+    const response = await request(app).get('/api/game/start');
     const { cards } = response.body;
 
     cards.forEach((card: any) => {
@@ -36,7 +45,7 @@ describe('GET /game/start', () => {
   });
 
   test('gameId should be a valid UUID', async () => {
-    const response = await request(app).get('/game/start');
+    const response = await request(app).get('/api/game/start');
     const { gameId } = response.body;
 
     // UUID v4 regex pattern
@@ -47,21 +56,21 @@ describe('GET /game/start', () => {
 
   test('response time should be under 200ms', async () => {
     const startTime = Date.now();
-    await request(app).get('/game/start');
+    await request(app).get('/api/game/start');
     const responseTime = Date.now() - startTime;
 
     expect(responseTime).toBeLessThan(200);
   });
 
   test('should return different gameIds on multiple calls', async () => {
-    const response1 = await request(app).get('/game/start');
-    const response2 = await request(app).get('/game/start');
+    const response1 = await request(app).get('/api/game/start');
+    const response2 = await request(app).get('/api/game/start');
 
     expect(response1.body.gameId).not.toBe(response2.body.gameId);
   });
 
   test('should have 2 cards of each fruit type', async () => {
-    const response = await request(app).get('/game/start');
+    const response = await request(app).get('/api/game/start');
     const { cards } = response.body;
 
     const typeCounts: { [key: string]: number } = {};


### PR DESCRIPTION
## Summary

- 백엔드 Jest 테스트 환경 검증 및 CI 연동 (Issue #84)
- `gameApi.test.ts` 경로 버그 수정: `/game/start` → `/api/game/start`
- 커버리지 임계값 80% 설정 및 통과 확인
- `backend-ci` Job에 `npm test` step 추가

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `backend/src/__tests__/gameApi.test.ts` | 경로 버그 수정 + `/health` 테스트 추가 |
| `backend/jest.config.js` | `coverageThreshold` 추가 (80%) |
| `.github/workflows/ci.yml` | `backend-ci`에 `Run tests (Jest + Supertest)` step 추가 |

## 버그 분석

`server.ts`에서 `app.use('/api/game', gameRouter)`로 마운트되어 있어
실제 경로는 `/api/game/start`이지만, `gameApi.test.ts`는 `/game/start`를 호출하고 있었습니다.
→ 8개 테스트가 모두 404 Not Found로 실패하던 상태였습니다.

## Test plan

- [x] `npm test` — 34 tests 전체 통과 (4 suites)
- [x] `npm run test:coverage` — 커버리지 임계값 80% 통과
  - Statements: **91.78%** ✅
  - Branches: **80%** ✅
  - Functions: **87.5%** ✅
  - Lines: **91.17%** ✅
- [x] `shuffle.ts`, `generateCards.ts` 함수 커버리지 100% ✅
- [x] `npm run build` — 빌드 성공

> **참고**: `server.ts`의 `app.listen()` 콜백은 `NODE_ENV=test` 환경에서 실행되지 않아
> 100% 커버리지 달성 불가 (설계상 정상). 전체 함수 커버리지 87.5%로 임계값 초과.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)