### PR TITLE
feat: 정적 분석 CI 연동 — ESLint + TypeScript typecheck (#85)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: ESLint 정적 분석
+        run: npm run lint
+
+      - name: TypeScript 타입 체크
+        run: npm run typecheck
+
       - name: Run unit tests (Vitest)
         run: npm test
 
@@ -60,6 +66,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: TypeScript 타입 체크
+        run: npm run typecheck
 
       - name: Run tests (Jest + Supertest)
         run: npm test

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "start": "node dist/server.js",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,5 +19,10 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // GameContext처럼 컴포넌트와 reducer/state를 함께 export하는 파일을 허용.
+      // allowConstantExport: true는 const 상수 export를 허용한다.
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
   },
 ])

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit -p tsconfig.app.json"
   },
   "dependencies": {
     "axios": "^1.13.4",

--- a/frontend/src/styles/styled.d.ts
+++ b/frontend/src/styles/styled.d.ts
@@ -6,5 +6,8 @@ import { Theme } from './theme';
  * styled-components의 DefaultTheme을 확장하여 타입 안정성 확보
  */
 declare module 'styled-components' {
+  // styled-components 모듈 증강 패턴: 빈 인터페이스가 Theme 타입을 DefaultTheme에 병합한다.
+  // interface 선언 병합(Declaration Merging)이 필요하므로 type alias로 대체 불가.
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   export interface DefaultTheme extends Theme {}
 }


### PR DESCRIPTION
## Summary

- 정적 분석 CI 연동 (Issue #85)
- `typecheck` 스크립트 추가 (frontend/backend 모두)
- ESLint lint 오류 수정 (0 errors 달성)
- CI `frontend-ci` / `backend-ci` 완성형: **lint → typecheck → test → build**

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `frontend/package.json` | `"typecheck": "tsc --noEmit -p tsconfig.app.json"` 추가 |
| `backend/package.json` | `"typecheck": "tsc --noEmit"` 추가 |
| `frontend/eslint.config.js` | `react-refresh/only-export-components` → `warn` 수준으로 조정 |
| `frontend/src/styles/styled.d.ts` | `eslint-disable-next-line` 추가 (모듈 증강 패턴 예외) |
| `.github/workflows/ci.yml` | lint + typecheck step 추가 (양쪽 job) |

## 린트 오류 수정 상세

**`react-refresh/only-export-components` (GameContext.tsx)**
> issue #83에서 단위 테스트를 위해 `gameReducer`/`initialState`를 export하면서 발생.
> React Fast Refresh는 컴포넌트만 export하는 파일에서만 완전히 동작하지만,
> `gameReducer` 같은 순수 함수는 HMR에 영향을 주지 않음.
> → `warn` 수준 조정으로 CI를 차단하지 않으면서 개발자에게 인지시킴.

**`no-empty-object-type` (styled.d.ts)**
> `export interface DefaultTheme extends Theme {}` — styled-components 공식 모듈 증강 패턴.
> TypeScript의 선언 병합(Declaration Merging)을 위해 `interface`가 필수;
> `type alias`로 교체 불가. → 의도된 패턴임을 주석으로 명시 후 inline disable.

## CI 완성형 파이프라인

```
frontend-ci: lint → typecheck → test → build
backend-ci:           typecheck → test → build
```

## Test plan

- [x] `npm run lint` → **0 errors** (3 warnings — CI 차단 없음) ✅
- [x] `npm run typecheck` → **0 errors** (frontend) ✅
- [x] `npm run typecheck` → **0 errors** (backend) ✅
- [x] `npm test` → 19 tests passed (frontend) ✅
- [x] `npm test` → 34 tests passed (backend) ✅
- [x] `npm run build` → 빌드 성공 ✅

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)