### PR TITLE
feat: CD 파이프라인 구축 - Playwright E2E + Docker + GitHub Actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,109 @@
+name: CD
+
+# ─────────────────────────────────────────────────────────
+# 트리거: CI 워크플로우 완료 후 자동 실행
+#
+# 교육적 관점 (DevOps):
+# 별도 파일의 워크플로우 간에는 needs:를 사용할 수 없다.
+# workflow_run 이벤트로 "CI가 성공한 경우에만" CD를 실행한다.
+# 이것이 CI → CD 체인을 만드는 GitHub Actions의 관용 패턴이다.
+# ─────────────────────────────────────────────────────────
+on:
+  workflow_run:
+    workflows: ["CI"]   # ci.yml의 name: CI 와 정확히 일치해야 함
+    types: [completed]
+    branches: [main]
+
+jobs:
+  # ─────────────────────────────────────────────────────────
+  # Job 1: E2E 테스트 (Playwright)
+  # CI가 성공한 경우에만 실행
+  # ─────────────────────────────────────────────────────────
+  e2e:
+    name: E2E Tests (Playwright)
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      # Backend 의존성 설치
+      - name: Install backend dependencies
+        run: npm ci
+        working-directory: backend
+
+      # Frontend 의존성 설치
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      # Playwright 및 브라우저 설치
+      - name: Install Playwright dependencies
+        run: npm ci
+        working-directory: e2e
+
+      - name: Install Playwright browsers (Chromium only)
+        run: npx playwright install chromium --with-deps
+        working-directory: e2e
+
+      # E2E 테스트 실행
+      # playwright.config.ts의 webServer 설정으로 backend + frontend 자동 기동
+      - name: Run E2E tests
+        run: npm test
+        working-directory: e2e
+        env:
+          CI: true
+
+      # 실패 시 HTML 리포트를 아티팩트로 업로드
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7
+
+  # ─────────────────────────────────────────────────────────
+  # Job 2: Docker 이미지 빌드 검증
+  # E2E 테스트 통과 후 실행
+  # ─────────────────────────────────────────────────────────
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    needs: [e2e]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Docker Buildx 설정 (멀티플랫폼 빌드 지원)
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Frontend 이미지 빌드 (push 없이 로컬 검증만)
+      - name: Build frontend Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: frontend/Dockerfile
+          push: false
+          tags: card-match-game/frontend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Backend 이미지 빌드 (push 없이 로컬 검증만)
+      - name: Build backend Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: backend/Dockerfile
+          push: false
+          tags: card-match-game/backend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+*.log
+.DS_Store
+coverage

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,39 @@
+# ─────────────────────────────────────────────────────────
+# Stage 1: Build
+# TypeScript를 JavaScript로 컴파일
+# ─────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ─────────────────────────────────────────────────────────
+# Stage 2: Runtime
+# 보안 강화: non-root 사용자로 실행
+# (root로 실행하면 컨테이너 탈출 시 호스트에도 root 권한이 생김)
+# ─────────────────────────────────────────────────────────
+FROM node:20-alpine
+
+# non-root 사용자 및 그룹 생성
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+
+# 프로덕션 의존성만 설치 (devDependencies 제외)
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# 빌드된 결과물만 복사
+COPY --from=builder /app/dist ./dist
+
+# non-root 사용자로 전환
+USER appuser
+
+EXPOSE 3001
+
+CMD ["node", "dist/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  # ─────────────────────────────────────────────────────────
+  # Backend: Express API 서버
+  # ─────────────────────────────────────────────────────────
+  backend:
+    build: ./backend
+    ports:
+      - "3001:3001"
+    environment:
+      NODE_ENV: production
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3001/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # ─────────────────────────────────────────────────────────
+  # Frontend: React 앱 (nginx로 서빙)
+  # /api 요청은 backend 서비스로 프록시
+  # ─────────────────────────────────────────────────────────
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    ports:
+      - "8080:80"
+    depends_on:
+      backend:
+        condition: service_healthy

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+playwright-report
+test-results

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.50.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "description": "Playwright E2E tests for card-match-game",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.1"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,68 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright 설정
+ *
+ * webServer 2개:
+ *  1. backend: Express on port 3001
+ *  2. frontend: Vite preview (빌드 결과물) on port 4173
+ *
+ * 교육적 관점 (DevOps):
+ * reuseExistingServer=true 로 개발 중에는 이미 띄워진 서버를 재사용하고,
+ * CI에서는 환경 변수 CI=true 라서 새 서버를 항상 기동한다.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* 타임아웃: 테스트 하나당 최대 30초 */
+  timeout: 30_000,
+  /* 기대값 타임아웃: UI 변화 대기 최대 5초 */
+  expect: {
+    timeout: 5_000,
+  },
+  /* CI에서는 병렬 실행 비활성화 (리소스 절약) */
+  workers: process.env.CI ? 1 : undefined,
+  /* 실패 시 재시도 없음 */
+  retries: 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+
+  use: {
+    /* 모든 테스트의 기본 URL */
+    baseURL: 'http://localhost:4173',
+    /* 실패 시 스크린샷 저장 */
+    screenshot: 'only-on-failure',
+    /* 실패 시 트레이스 저장 */
+    trace: 'on-first-retry',
+  },
+
+  /* Chromium 단일 브라우저만 사용 (CI 속도 최적화) */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /**
+   * webServer 설정
+   * Playwright가 테스트 실행 전 자동으로 서버를 기동합니다.
+   *
+   * - backend: ts-node-dev로 TypeScript 소스를 바로 실행
+   * - frontend: 먼저 빌드 후 preview 서버 기동 (실제 nginx와 유사한 환경)
+   */
+  webServer: [
+    {
+      command: 'npm run dev',
+      cwd: '../backend',
+      port: 3001,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+    {
+      command: 'npm run build && npm run preview',
+      cwd: '../frontend',
+      port: 4173,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+  ],
+})

--- a/e2e/tests/game.spec.ts
+++ b/e2e/tests/game.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * 카드 매칭 게임 E2E 테스트
+ *
+ * 교육적 관점 (Testing Strategy):
+ * E2E 테스트는 "사용자 시나리오 중심"으로 작성합니다.
+ * 단위 테스트(Vitest)가 로직을 검증한다면, E2E 테스트는 전체 시스템이
+ * 실제 브라우저에서 올바르게 동작하는지 확인합니다.
+ *
+ * 선택자 전략: data-testid 속성 사용
+ * CSS 클래스나 텍스트 대신 data-testid를 사용하면,
+ * UI 스타일이나 국제화(i18n)가 변경돼도 테스트가 깨지지 않습니다.
+ */
+
+test.describe('카드 매칭 게임', () => {
+  /**
+   * 시나리오 1: 게임 로딩
+   * 페이지 접속 시 16개 카드가 렌더링되는지 확인
+   */
+  test('게임 로딩 - 카드 16장이 렌더링된다', async ({ page }) => {
+    await page.goto('/')
+
+    // 게임 보드가 나타날 때까지 대기
+    await expect(page.getByTestId('game-board')).toBeVisible()
+
+    // 생명(기회) 표시 확인
+    await expect(page.getByTestId('life-display')).toHaveText('남은 기회: 3/3')
+
+    // 카드 16장 확인 (data-testid="card-{id}" 형태)
+    const cards = page.locator('[data-testid^="card-"]')
+    await expect(cards).toHaveCount(16)
+
+    // 모든 카드가 뒤집히지 않은 상태여야 함
+    const flippedCards = page.locator('[data-is-flipped="true"]')
+    await expect(flippedCards).toHaveCount(0)
+  })
+
+  /**
+   * 시나리오 2: 카드 뒤집기
+   * 카드 클릭 시 data-is-flipped 속성이 true로 변경되는지 확인
+   */
+  test('카드 뒤집기 - 클릭하면 뒤집힌 상태가 된다', async ({ page }) => {
+    await page.goto('/')
+
+    // 게임 보드 대기
+    await expect(page.getByTestId('game-board')).toBeVisible()
+
+    // 첫 번째 카드 클릭
+    const firstCard = page.locator('[data-testid^="card-"]').first()
+    await firstCard.click()
+
+    // 클릭 후 해당 카드가 뒤집힌 상태인지 확인
+    await expect(firstCard).toHaveAttribute('data-is-flipped', 'true')
+  })
+
+  /**
+   * 시나리오 3: 매칭 실패
+   * 서로 다른 타입의 카드 2장을 클릭하면:
+   * - 잠시 후 두 카드가 다시 뒤집힌다
+   * - 생명이 1 감소한다 (3 → 2)
+   *
+   * 구현 세부사항:
+   * 서로 다른 타입의 카드를 찾기 위해 data-card-type 속성을 활용합니다.
+   * 매칭 판별 대기 시간은 1초 + 여유 시간 = 최대 2.5초로 설정합니다.
+   */
+  test('매칭 실패 - 다른 타입 카드 클릭 시 생명이 감소한다', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('game-board')).toBeVisible()
+
+    // 모든 카드 가져오기
+    const allCards = page.locator('[data-testid^="card-"]')
+    await expect(allCards).toHaveCount(16)
+
+    // 첫 번째 카드 클릭
+    const firstCard = allCards.nth(0)
+    await firstCard.click()
+    await expect(firstCard).toHaveAttribute('data-is-flipped', 'true')
+
+    // 첫 번째 카드 타입 가져오기
+    const firstType = await firstCard.getAttribute('data-card-type')
+
+    // 첫 번째와 다른 타입의 카드 찾기
+    const differentCard = page.locator(`[data-testid^="card-"]:not([data-card-type="${firstType}"])`).first()
+    await differentCard.click()
+
+    // 매칭 실패 후 1초 + 여유 시간 대기
+    // (게임 로직: 1000ms 후 MATCH_FAIL 디스패치)
+    await page.waitForTimeout(2000)
+
+    // 두 카드 모두 다시 뒤집혀야 함 (뒤집힌 카드 0장)
+    const stillFlipped = page.locator('[data-is-flipped="true"]')
+    await expect(stillFlipped).toHaveCount(0)
+
+    // 생명이 1 감소해야 함 (3 → 2)
+    await expect(page.getByTestId('life-display')).toHaveText('남은 기회: 2/3')
+  })
+
+  /**
+   * 시나리오 4: 게임 재시작
+   * 게임 오버 후 재시작 버튼 클릭 시:
+   * - ResultModal이 닫힌다
+   * - 생명이 3/3으로 초기화된다
+   * - 카드 16장이 다시 렌더링된다
+   *
+   * 교육적 관점:
+   * 게임 오버를 빠르게 만들기 위해 3번 연속 매칭 실패를 시뮬레이션합니다.
+   */
+  test('게임 재시작 - 재시작 버튼 클릭 시 상태가 초기화된다', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('game-board')).toBeVisible()
+
+    // 3번 매칭 실패로 게임 오버 유도
+    for (let i = 0; i < 3; i++) {
+      // data-testid를 먼저 가져와 고정된 로케이터 생성
+      // (Playwright locator는 동적 재평가되므로, 클릭 후 속성이 변하면 다른 카드로 이동함)
+      const firstTestId = await page
+        .locator('[data-testid^="card-"][data-is-flipped="false"]')
+        .first()
+        .getAttribute('data-testid')
+      const firstCard = page.locator(`[data-testid="${firstTestId}"]`)
+      await firstCard.click()
+      await expect(firstCard).toHaveAttribute('data-is-flipped', 'true')
+      const firstType = await firstCard.getAttribute('data-card-type')
+
+      // 다른 타입의 카드 클릭
+      const differentCard = page
+        .locator(`[data-testid^="card-"][data-is-flipped="false"]:not([data-card-type="${firstType}"])`)
+        .first()
+      await differentCard.click()
+
+      // 매칭 실패 대기
+      await page.waitForTimeout(1500)
+    }
+
+    // ResultModal이 표시되어야 함
+    await expect(page.getByTestId('result-modal')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByTestId('modal-title')).toHaveText('게임 오버')
+
+    // 재시작 버튼 클릭
+    await page.getByTestId('restart-button').click()
+
+    // 새 게임: 생명 3/3으로 초기화 확인
+    await expect(page.getByTestId('life-display')).toHaveText('남은 기회: 3/3', { timeout: 10000 })
+
+    // 카드 16장 다시 확인
+    const newCards = page.locator('[data-testid^="card-"]')
+    await expect(newCards).toHaveCount(16)
+  })
+})

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.env
+.env.local
+.env.*.local
+*.log
+.DS_Store
+coverage

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,32 @@
+# ─────────────────────────────────────────────────────────
+# Stage 1: Build
+# node:20-alpine으로 React 앱 빌드
+# ─────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# package.json만 먼저 복사하여 레이어 캐시 활용
+# (소스 변경 시 npm ci를 재실행하지 않아도 됨)
+COPY package*.json ./
+RUN npm ci
+
+# 소스 코드 복사 및 빌드
+COPY . .
+RUN npm run build
+
+# ─────────────────────────────────────────────────────────
+# Stage 2: Serve
+# nginx:alpine으로 정적 파일 서빙 (이미지 크기 최소화)
+# ─────────────────────────────────────────────────────────
+FROM nginx:alpine
+
+# 빌드 결과물을 nginx의 html 디렉토리로 복사
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# SPA 라우팅 + /api 프록시 설정
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -260,7 +260,7 @@ function Game() {
   if (state.isLoading) {
     return (
       <GameContainer>
-        <LoadingContainer>Loading...</LoadingContainer>
+        <LoadingContainer data-testid="loading-screen">Loading...</LoadingContainer>
       </GameContainer>
     )
   }

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -109,7 +109,13 @@ export const Card: React.FC<CardProps> = ({ cardData, onClick }) => {
   const showFront = isFlipped || isSolved
 
   return (
-    <CardContainer onClick={onClick}>
+    <CardContainer
+      onClick={onClick}
+      data-testid={`card-${cardData.id}`}
+      data-card-type={type}
+      data-is-flipped={String(isFlipped)}
+      data-is-solved={String(isSolved)}
+    >
       <CardInner $showFront={showFront}>
         {/* 카드 뒷면 (기본 상태) */}
         <CardBack />

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -63,7 +63,7 @@ export const GameBoard: React.FC<GameBoardProps> = ({
   isMatching,
 }) => {
   return (
-    <BoardContainer $isMatching={isMatching}>
+    <BoardContainer $isMatching={isMatching} data-testid="game-board">
       {cards.map((card) => (
         <CardWrapper key={card.id}>
           <Card cardData={card} onClick={() => onCardClick(card.id)} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -48,7 +48,7 @@ const LifeText = styled.div`
 export const Header: React.FC<HeaderProps> = ({ life }) => {
   return (
     <HeaderContainer>
-      <LifeText>남은 기회: {life}/3</LifeText>
+      <LifeText data-testid="life-display">남은 기회: {life}/3</LifeText>
     </HeaderContainer>
   )
 }

--- a/frontend/src/components/ResultModal.tsx
+++ b/frontend/src/components/ResultModal.tsx
@@ -170,12 +170,12 @@ export const ResultModal: React.FC<ResultModalProps> = ({
       : '아쉽네요. 다시 도전해보세요!'
 
   return (
-    <ModalOverlay $isOpen={isOpen}>
+    <ModalOverlay $isOpen={isOpen} data-testid="result-modal">
       <ModalContent>
         <ModalEmoji>{emoji}</ModalEmoji>
-        <ModalTitle $result={result}>{title}</ModalTitle>
+        <ModalTitle $result={result} data-testid="modal-title">{title}</ModalTitle>
         <ModalMessage>{message}</ModalMessage>
-        <RestartButton onClick={onRestart}>게임 재시작</RestartButton>
+        <RestartButton onClick={onRestart} data-testid="restart-button">게임 재시작</RestartButton>
       </ModalContent>
     </ModalOverlay>
   )

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # /api 요청은 백엔드 컨테이너로 프록시
+    # docker-compose에서 서비스 이름 'backend'가 DNS로 해석됨
+    location /api/ {
+        proxy_pass http://backend:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # SPA 라우팅: 없는 경로는 index.html로 fallback
+    # (React Router 사용 시 새로고침 404 방지)
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary

- **Playwright E2E 테스트** 4개 시나리오: 게임 로딩, 카드 뒤집기, 매칭 실패, 게임 재시작 (로컬 4/4 통과)
- **data-testid 속성** 추가: Card, GameBoard, Header, ResultModal, App 컴포넌트 (E2E 셀렉터 안정성)
- **Docker 멀티스테이지 빌드**: frontend(nginx:alpine), backend(non-root node:20-alpine)
- **GitHub Actions `cd.yml`**: CI 성공 후 `workflow_run`으로 트리거 → E2E → Docker build

## 파일 구조

```
card-match-game/
├── .github/workflows/cd.yml   # CD 워크플로우 (workflow_run 트리거)
├── e2e/
│   ├── package.json
│   ├── playwright.config.ts   # webServer: backend:3001 + frontend:4173
│   └── tests/game.spec.ts     # 4개 시나리오
├── frontend/
│   ├── Dockerfile             # 멀티스테이지: node→nginx
│   └── .dockerignore
├── backend/
│   ├── Dockerfile             # 멀티스테이지: build→non-root runtime
│   └── .dockerignore
├── nginx.conf                 # SPA 라우팅 + /api 프록시
└── docker-compose.yml         # frontend:8080, backend:3001
```

## Test Plan

- [x] `npm test` (e2e/) — 로컬 4/4 통과 (10.8초)
- [x] `npm run typecheck` (frontend/) — 오류 없음
- [x] `npm run lint` (frontend/) — 에러 없음 (기존 warning 3개만)
- [ ] CI 통과 후 cd.yml 자동 트리거 확인
- [ ] Docker Compose 로컬 실행 검증: `docker compose up --build`

## 로컬 실행 방법

```bash
# E2E 테스트
cd e2e && npm ci && npx playwright install chromium
npm test

# Docker Compose
docker compose up --build
# http://localhost:8080 프론트엔드
# http://localhost:8080/api/game/start API 프록시
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)