### PR TITLE
feat: E2E 테스트 환경 구축 (Playwright)

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+playwright-report
+test-results

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "description": "Playwright E2E tests for card-match-game",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.1"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Playwright E2E 설정
+ *
+ * webServer 2개 자동 기동:
+ *  1. backend: Express (port 3001)
+ *  2. frontend: Vite preview (port 4173) — 빌드 후 정적 파일 서빙
+ *
+ * 교육적 관점 (Testing Strategy):
+ * E2E 테스트는 실제 브라우저 + 실서버 조합으로 "사용자 시나리오"를 검증한다.
+ * webServer.reuseExistingServer=!CI 설정으로,
+ *   - 로컬: 이미 띄워진 서버 재사용 (개발 편의성)
+ *   - CI: 항상 새 서버 기동 (결정론적 환경 보장)
+ */
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  workers: process.env.CI ? 1 : undefined,
+  retries: 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+
+  use: {
+    baseURL: 'http://localhost:4173',
+    screenshot: 'only-on-failure',  // AC: 실패 시 스크린샷 저장
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: [
+    {
+      command: 'npm run dev',
+      cwd: '../backend',
+      port: 3001,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+    },
+    {
+      command: 'npm run build && npm run preview',
+      cwd: '../frontend',
+      port: 4173,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+  ],
+})

--- a/e2e/tests/game.spec.ts
+++ b/e2e/tests/game.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * 카드 매칭 게임 E2E 테스트
+ *
+ * 이슈 #93 AC 기반 3개 시나리오:
+ *  1. 게임 페이지 접속 여부 확인
+ *  2. 카드 클릭 시 뒤집힘(Flip) 확인
+ *  3. 카드 매칭 성공/실패 상태 변화 검증 (실패 → 생명 감소 / 재시작 → 초기화)
+ *
+ * 교육적 관점 (Testing Strategy):
+ * CSS 클래스·텍스트 대신 data-testid 셀렉터를 사용하면
+ * 스타일 변경·국제화(i18n)에 테스트가 영향을 받지 않는다.
+ */
+
+test.describe('카드 매칭 게임', () => {
+  /**
+   * AC1: 게임 페이지 접속 여부 확인
+   * - 카드 16장 렌더링 + data-testid="game-board" 노출
+   * - 생명 3/3 초기값
+   * - 모든 카드 뒤집히지 않은 상태
+   */
+  test('게임 로딩 — 카드 16장이 렌더링된다', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByTestId('game-board')).toBeVisible()
+    await expect(page.getByTestId('life-display')).toHaveText('남은 기회: 3/3')
+
+    const cards = page.locator('[data-testid^="card-"]')
+    await expect(cards).toHaveCount(16)
+
+    const flippedCards = page.locator('[data-is-flipped="true"]')
+    await expect(flippedCards).toHaveCount(0)
+  })
+
+  /**
+   * AC2: 카드 클릭 시 뒤집힘(Flip) 확인
+   * - 클릭 후 data-is-flipped="true" 속성 변화
+   */
+  test('카드 뒤집기 — 클릭하면 data-is-flipped가 true가 된다', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('game-board')).toBeVisible()
+
+    const firstCard = page.locator('[data-testid^="card-"]').first()
+    await firstCard.click()
+
+    await expect(firstCard).toHaveAttribute('data-is-flipped', 'true')
+  })
+
+  /**
+   * AC3-A: 매칭 실패 → 생명 감소 검증
+   * - 서로 다른 타입 2장 클릭
+   * - 1초(게임 로직) + 여유 시간 후 카드 원복
+   * - 생명 3 → 2 감소
+   */
+  test('매칭 실패 — 다른 타입 카드 클릭 시 생명이 감소한다', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('game-board')).toBeVisible()
+
+    const firstCard = page.locator('[data-testid^="card-"]').first()
+    await firstCard.click()
+    await expect(firstCard).toHaveAttribute('data-is-flipped', 'true')
+
+    const firstType = await firstCard.getAttribute('data-card-type')
+
+    const differentCard = page
+      .locator(`[data-testid^="card-"]:not([data-card-type="${firstType}"])`)
+      .first()
+    await differentCard.click()
+
+    // 게임 로직: 1000ms 후 MATCH_FAIL 디스패치
+    await page.waitForTimeout(2000)
+
+    await expect(page.locator('[data-is-flipped="true"]')).toHaveCount(0)
+    await expect(page.getByTestId('life-display')).toHaveText('남은 기회: 2/3')
+  })
+
+  /**
+   * AC3-B: 게임 재시작 → 상태 초기화 검증
+   * - 3회 매칭 실패 → 게임 오버 → ResultModal 노출
+   * - 재시작 버튼 클릭 → 생명 3/3 초기화, 카드 16장 재렌더링
+   */
+  test('게임 재시작 — 재시작 버튼 클릭 시 상태가 초기화된다', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByTestId('game-board')).toBeVisible()
+
+    // 3회 매칭 실패로 게임 오버 유도
+    for (let i = 0; i < 3; i++) {
+      // data-testid를 먼저 캡처하여 고정 로케이터 생성
+      // (Playwright locator는 평가 시점마다 재조회되므로 클릭 후 속성 변화로 이동 방지)
+      const firstTestId = await page
+        .locator('[data-testid^="card-"][data-is-flipped="false"]')
+        .first()
+        .getAttribute('data-testid')
+      const firstCard = page.locator(`[data-testid="${firstTestId}"]`)
+      await firstCard.click()
+      await expect(firstCard).toHaveAttribute('data-is-flipped', 'true')
+      const firstType = await firstCard.getAttribute('data-card-type')
+
+      const differentCard = page
+        .locator(`[data-testid^="card-"][data-is-flipped="false"]:not([data-card-type="${firstType}"])`)
+        .first()
+      await differentCard.click()
+
+      await page.waitForTimeout(1500)
+    }
+
+    // ResultModal 표시 확인
+    await expect(page.getByTestId('result-modal')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByTestId('modal-title')).toHaveText('게임 오버')
+
+    // 재시작
+    await page.getByTestId('restart-button').click()
+
+    // 상태 초기화 확인
+    await expect(page.getByTestId('life-display')).toHaveText('남은 기회: 3/3', { timeout: 10000 })
+    await expect(page.locator('[data-testid^="card-"]')).toHaveCount(16)
+  })
+})

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -260,7 +260,7 @@ function Game() {
   if (state.isLoading) {
     return (
       <GameContainer>
-        <LoadingContainer>Loading...</LoadingContainer>
+        <LoadingContainer data-testid="loading-screen">Loading...</LoadingContainer>
       </GameContainer>
     )
   }

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -109,7 +109,13 @@ export const Card: React.FC<CardProps> = ({ cardData, onClick }) => {
   const showFront = isFlipped || isSolved
 
   return (
-    <CardContainer onClick={onClick}>
+    <CardContainer
+      onClick={onClick}
+      data-testid={`card-${cardData.id}`}
+      data-card-type={type}
+      data-is-flipped={String(isFlipped)}
+      data-is-solved={String(isSolved)}
+    >
       <CardInner $showFront={showFront}>
         {/* 카드 뒷면 (기본 상태) */}
         <CardBack />

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -63,7 +63,7 @@ export const GameBoard: React.FC<GameBoardProps> = ({
   isMatching,
 }) => {
   return (
-    <BoardContainer $isMatching={isMatching}>
+    <BoardContainer $isMatching={isMatching} data-testid="game-board">
       {cards.map((card) => (
         <CardWrapper key={card.id}>
           <Card cardData={card} onClick={() => onCardClick(card.id)} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -48,7 +48,7 @@ const LifeText = styled.div`
 export const Header: React.FC<HeaderProps> = ({ life }) => {
   return (
     <HeaderContainer>
-      <LifeText>남은 기회: {life}/3</LifeText>
+      <LifeText data-testid="life-display">남은 기회: {life}/3</LifeText>
     </HeaderContainer>
   )
 }

--- a/frontend/src/components/ResultModal.tsx
+++ b/frontend/src/components/ResultModal.tsx
@@ -170,12 +170,12 @@ export const ResultModal: React.FC<ResultModalProps> = ({
       : '아쉽네요. 다시 도전해보세요!'
 
   return (
-    <ModalOverlay $isOpen={isOpen}>
+    <ModalOverlay $isOpen={isOpen} data-testid="result-modal">
       <ModalContent>
         <ModalEmoji>{emoji}</ModalEmoji>
-        <ModalTitle $result={result}>{title}</ModalTitle>
+        <ModalTitle $result={result} data-testid="modal-title">{title}</ModalTitle>
         <ModalMessage>{message}</ModalMessage>
-        <RestartButton onClick={onRestart}>게임 재시작</RestartButton>
+        <RestartButton onClick={onRestart} data-testid="restart-button">게임 재시작</RestartButton>
       </ModalContent>
     </ModalOverlay>
   )


### PR DESCRIPTION
## Summary

`e2e/` 디렉토리를 신규 구성하여 Playwright 기반 E2E 테스트 환경을 구축합니다.
`webServer` 옵션으로 Backend + Frontend 서버를 자동 기동하고,
`data-testid` 셀렉터 기반으로 4개 시나리오를 검증합니다.

Closes #93

---

## 변경 내용

| 파일 | 유형 | 설명 |
|---|---|---|
| `e2e/package.json` | 신규 | `@playwright/test` 의존성 |
| `e2e/playwright.config.ts` | 신규 | webServer 2개 설정, Chromium Headless |
| `e2e/tests/game.spec.ts` | 신규 | E2E 테스트 시나리오 4개 |
| `frontend/src/components/Card.tsx` | 수정 | `data-testid`, `data-card-type`, `data-is-flipped`, `data-is-solved` 추가 |
| `frontend/src/components/GameBoard.tsx` | 수정 | `data-testid="game-board"` 추가 |
| `frontend/src/components/Header.tsx` | 수정 | `data-testid="life-display"` 추가 |
| `frontend/src/components/ResultModal.tsx` | 수정 | `data-testid="result-modal/modal-title/restart-button"` 추가 |
| `frontend/src/App.tsx` | 수정 | `data-testid="loading-screen"` 추가 |

## Acceptance Criteria 검증

- [x] `npm test` (e2e/) — **4/4 통과** (11.4초, Headless 모드)
- [x] `webServer` 설정으로 서버 자동 기동 확인
- [x] 실패 시 스크린샷 → `screenshot: 'only-on-failure'` 설정
- [x] typecheck: 에러 없음 / lint: 에러 0개 (warning 3개는 기존)

## 테스트 결과

```
✓ 게임 로딩 — 카드 16장이 렌더링된다            (311ms)
✓ 카드 뒤집기 — data-is-flipped가 true가 된다  (226ms)
✓ 매칭 실패 — 생명이 감소한다                  (2.3s)
✓ 게임 재시작 — 상태가 초기화된다              (5.0s)
4 passed (11.4s)
```

## Test Plan

- [x] 로컬 Headless 모드 4/4 통과 확인
- [ ] CI 파이프라인 통과 확인 (PR #96 머지 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)