### PR TITLE
feat: Docker 멀티스테이지 빌드 구성 (Frontend / Backend)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+*.log
+.DS_Store
+coverage

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,43 @@
+# ─────────────────────────────────────────────────────────
+# Stage 1: Build
+# TypeScript → JavaScript 컴파일 (dist/ 생성)
+# ─────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+# ─────────────────────────────────────────────────────────
+# Stage 2: Runtime
+# 보안 강화: non-root 사용자(appuser)로 실행
+#
+# 교육적 관점 (Security Best Practice):
+# root로 실행하면 컨테이너 탈출 시 호스트에도 root 권한이 생긴다.
+# non-root 사용자 실행은 컨테이너 보안의 핵심 원칙이다.
+# --omit=dev 로 devDependencies 제외 → 이미지 크기 최소화
+# ─────────────────────────────────────────────────────────
+FROM node:20-alpine
+
+# non-root 그룹/사용자 생성
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+
+# 프로덕션 의존성만 설치
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# 빌드 산출물만 복사
+COPY --from=builder /app/dist ./dist
+
+# non-root 사용자로 전환
+USER appuser
+
+EXPOSE 3001
+
+CMD ["node", "dist/server.js"]

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.env
+.env.local
+.env.*.local
+*.log
+.DS_Store
+coverage

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,37 @@
+# ─────────────────────────────────────────────────────────
+# Stage 1: Build
+# node:20-alpine으로 React 앱 빌드
+#
+# 교육적 관점 (Docker Best Practice):
+# package*.json 먼저 COPY 후 npm ci → 소스 변경 시에도
+# 의존성 레이어가 캐시되어 재빌드 속도가 크게 향상된다.
+# ─────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# 의존성만 먼저 복사 (레이어 캐시 최적화)
+COPY package*.json ./
+RUN npm ci
+
+# 소스 복사 및 프로덕션 빌드 (dist/ 생성)
+COPY . .
+RUN npm run build
+
+# ─────────────────────────────────────────────────────────
+# Stage 2: Serve
+# nginx:alpine으로 정적 파일 서빙
+#
+# node_modules (~300MB)가 최종 이미지에 포함되지 않음 → 이미지 경량화
+# ─────────────────────────────────────────────────────────
+FROM nginx:alpine
+
+# 빌드 산출물만 복사 (node_modules 제외)
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# SPA 라우팅 + /api 프록시 설정
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # /api/ 요청 → backend 컨테이너로 프록시
+    # docker-compose에서 서비스 이름 'backend'가 내부 DNS로 해석됨
+    location /api/ {
+        proxy_pass http://backend:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # SPA 라우팅: 없는 경로는 index.html로 fallback
+    # React Router 사용 시 새로고침 404 방지
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary

보안과 이미지 크기 최적화를 위해 Frontend / Backend의 멀티스테이지 Dockerfile을 작성합니다.
nginx.conf로 SPA 라우팅과 `/api/` 프록시를 설정합니다.

Closes #94

---

## 변경 내용

| 파일 | 유형 | 설명 |
|---|---|---|
| `frontend/Dockerfile` | 신규 | `node:20-alpine`(빌드) → `nginx:alpine`(서빙) |
| `frontend/.dockerignore` | 신규 | `node_modules`, `dist` 등 제외 |
| `backend/Dockerfile` | 신규 | `node:20-alpine`(빌드) → non-root 런타임 |
| `backend/.dockerignore` | 신규 | `node_modules`, `dist` 등 제외 |
| `nginx.conf` | 신규 | `/api/` 프록시 + SPA `try_files` 라우팅 |

## Acceptance Criteria 검증

- [x] Frontend Dockerfile — 멀티스테이지: `AS builder` → `nginx:alpine` (node_modules 미포함)
- [x] Backend Dockerfile — 멀티스테이지: `AS builder` → non-root `appuser` 런타임
- [x] Backend non-root: `addgroup/adduser` + `USER appuser` 확인
- [x] Frontend 최종 레이어: `COPY --from=builder /app/dist`만 복사 (.dockerignore + 멀티스테이지)
- [x] nginx `/api/` → `proxy_pass http://backend:3001`, SPA `try_files $uri $uri/ /index.html`

## 멀티스테이지 빌드 구조

```
Frontend:
  Stage 1 (builder/node:20-alpine) → npm ci → npm run build → dist/
  Stage 2 (nginx:alpine)           → COPY dist/ → nginx 서빙
  최종 이미지: ~50MB (node_modules ~300MB 제외)

Backend:
  Stage 1 (builder/node:20-alpine) → npm ci → tsc → dist/
  Stage 2 (node:20-alpine)         → npm ci --omit=dev → COPY dist/ → USER appuser
  최종 이미지: devDependencies 제외, non-root 실행
```

## Test Plan

- [x] 파일 구조 AC 항목 전체 grep 검증 통과
- [ ] `docker build` 실제 빌드 검증 — #95 docker-compose PR에서 통합 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)