### PR TITLE
feat: 로컬 통합 실행 환경 구축 (docker-compose.yml)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  # ─────────────────────────────────────────────────────────
+  # Backend: Express API 서버 (port 3001)
+  #
+  # 교육적 관점 (DevOps):
+  # healthcheck로 backend가 완전히 기동된 후에만 frontend가 시작된다.
+  # depends_on.condition: service_healthy 가 이를 보장한다.
+  # ─────────────────────────────────────────────────────────
+  backend:
+    build: ./backend
+    ports:
+      - "3001:3001"
+    environment:
+      NODE_ENV: production
+    healthcheck:
+      # GET /health → { status: 'ok' } 응답 확인
+      test: ["CMD", "wget", "-qO-", "http://localhost:3001/health"]
+      interval: 10s      # 10초마다 체크
+      timeout: 5s        # 5초 안에 응답 없으면 실패
+      retries: 3         # 3회 연속 실패 시 unhealthy
+      start_period: 10s  # 기동 초기 10초는 실패 무시
+
+  # ─────────────────────────────────────────────────────────
+  # Frontend: React 앱 (nginx로 서빙, port 8080)
+  #
+  # build.context를 루트(.)로 설정하는 이유:
+  # frontend/Dockerfile에서 루트의 nginx.conf를 COPY해야 하기 때문
+  # ─────────────────────────────────────────────────────────
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    ports:
+      - "8080:80"
+    depends_on:
+      backend:
+        condition: service_healthy  # AC: backend healthy 후에만 기동


### PR DESCRIPTION
## Summary

`docker compose up --build` 단일 명령으로 Frontend + Backend 전체 시스템을
로컬에서 실행할 수 있는 `docker-compose.yml`을 구현합니다.

Closes #95

---

## 변경 내용

| 파일 | 유형 | 설명 |
|---|---|---|
| `docker-compose.yml` | 신규 | backend(3001) + frontend(8080) 통합 실행 |

## 서비스 구조

```
docker compose up --build
        │
        ├── [backend]  ./backend Dockerfile 빌드
        │   port: 3001
        │   healthcheck: GET /health → { status: 'ok' }
        │   start_period: 10s, interval: 10s, retries: 3
        │
        └── [frontend] context=. / frontend/Dockerfile 빌드
            port: 8080 → nginx:80
            depends_on: backend (condition: service_healthy)
            nginx: /api/ → proxy_pass backend:3001
                   /     → try_files (SPA 라우팅)
```

## Acceptance Criteria 검증

- [x] `http://localhost:8080` → frontend 정상 로딩 (nginx:80 → port 8080)
- [x] `http://localhost:8080/api/game/start` → backend 프록시 (`proxy_pass http://backend:3001`)
- [x] Healthcheck 통과 → `GET /health` 기구현 (`{ status: 'ok' }`, 테스트 #84에서 검증됨)
- [x] `docker compose down` → 컨테이너 정리 (`docker-compose.yml` 기반 자동 처리)

## 로컬 실행 방법

```bash
# 전체 기동 (이미지 빌드 포함)
docker compose up --build

# 백그라운드 실행
docker compose up --build -d

# 접속 확인
curl http://localhost:8080               # 프론트엔드
curl http://localhost:8080/api/game/start # API 프록시

# 종료 및 정리
docker compose down
```

## 핵심 설계 포인트

**`depends_on.condition: service_healthy`**
단순 `depends_on`은 컨테이너가 "시작"됐는지만 체크하지만,
`service_healthy`는 healthcheck가 통과할 때까지 대기한다.
Express 서버가 완전히 Ready 상태일 때만 nginx가 프록시를 시작한다.

**`context: .` (루트 컨텍스트)**
`frontend/Dockerfile`에서 루트의 `nginx.conf`를 `COPY`하려면
build context가 프로젝트 루트여야 한다.

## Test Plan

- [x] AC 항목 구조 검증 전체 통과
- [ ] `docker compose up --build` 실제 실행 검증 (Docker 설치 환경 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)