### PR TITLE
fix: CD 파이프라인 실패 원인 2건 수정 (e2e package-lock + Dockerfile COPY 경로)

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "e2e",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.50.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 문제

GitHub Actions CD 워크플로우가 2가지 원인으로 실패함.

---

### 원인 1 — E2E Tests: `e2e/package-lock.json` 누락

```
npm error The `npm ci` command can only install with an existing package-lock.json
Error: Process completed with exit code 1.
```

`e2e/package-lock.json`이 git에 추가되지 않아 CI 환경에 파일이 없음.

---

### 원인 2 — Docker Build: `frontend/Dockerfile` COPY 경로 오류

```
#13 ERROR: process "/bin/sh -c npm ci" did not complete successfully: exit code: 1
Dockerfile:15
  14 |     COPY package*.json ./   ← 루트에 package.json이 없음
  15 | >>> RUN npm ci
```

`docker-compose.yml`의 `build.context: .` (루트)이므로, Dockerfile 내 COPY는
`frontend/` 접두사가 필요함. 기존 코드는 루트의 `package.json`을 찾다가 실패.

---

## 수정 내용

| 파일 | 수정 |
|------|------|
| `e2e/package-lock.json` | git 추적 파일로 추가 |
| `frontend/Dockerfile` | `COPY package*.json ./` → `COPY frontend/package*.json ./` |
| `frontend/Dockerfile` | `COPY . .` → `COPY frontend/ .` |

## 검증 기준

- `cd e2e && npm ci` 정상 동작 ✅
- `docker compose up --build` 로컬에서 성공 확인 ✅ (이전 세션)

🤖 Generated with [Claude Code](https://claude.com/claude-code)