### PR TITLE
fix: frontend/Dockerfile COPY 경로 수정 (Docker Build CD 실패)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,11 +11,12 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 
 # 의존성만 먼저 복사 (레이어 캐시 최적화)
-COPY package*.json ./
+# build context가 루트(.)이므로 frontend/ 경로 명시
+COPY frontend/package*.json ./
 RUN npm ci
 
 # 소스 복사 및 프로덕션 빌드 (dist/ 생성)
-COPY . .
+COPY frontend/ .
 RUN npm run build
 
 # ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## 문제

CD 워크플로우 **Docker Build** 잡 실패:

```
#13 ERROR: process "/bin/sh -c npm ci" did not complete successfully: exit code: 1

Dockerfile:15
  14 |     COPY package*.json ./   ← 루트에 package.json 없음
  15 | >>> RUN npm ci
```

## 원인

`docker-compose.yml`의 `build.context: .` (루트)이므로, Dockerfile 내 COPY는 루트 기준으로 해석됨.
루트에 `package.json`이 없어 `npm ci`가 lock 파일을 못 찾고 실패.

## 수정

```diff
-COPY package*.json ./
+COPY frontend/package*.json ./

-COPY . .
+COPY frontend/ .
```

## 검증

로컬 `docker compose up --build` 성공 확인 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)