### PR TITLE
ci: backend-ci job 커버리지 검증 step 추가 (#104)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,10 @@ jobs:
       - name: Run tests (Jest + Supertest)
         run: npm test
 
+      # AC: 커버리지 임계값(전 항목 80%) 미달 시 빌드 실패
+      # jest.config.js의 coverageThreshold 설정이 여기서 실제로 적용됨
+      - name: Run tests with coverage (threshold 80%)
+        run: npm run test:coverage
+
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary

Closes #104

`ci.yml`의 `backend-ci` job에 `npm run test:coverage` step을 추가하여,
`jest.config.js`에 설정된 커버리지 임계값(전 항목 80%)이 CI에서 실제로 검증되도록 함.

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `.github/workflows/ci.yml` | `backend-ci` job에 coverage step 추가 |

## 변경 내용

```yaml
# 추가된 step
- name: Run tests with coverage (threshold 80%)
  run: npm run test:coverage
```

`npm run test:coverage` = `jest --coverage` → `jest.config.js`의 `coverageThreshold` 적용  
임계값 미달 시 CI 빌드 실패 → **코드 품질 게이트** 역할

## 로컬 검증 결과

| 항목 | 수치 | 임계값 | 상태 |
|------|------|--------|------|
| Statements | 95.89% | 80% | ✅ |
| Branches | 90.00% | 80% | ✅ |
| Functions | 87.50% | 80% | ✅ |
| Lines | 95.58% | 80% | ✅ |

```
Test Suites: 5 passed, 5 total
Tests:       44 passed, 44 total
```

## 관련 이슈

- 상위 이슈: #102
- 선행 완료: #103 (Phase 1 — gameController 유닛 테스트 구현)

🤖 Generated with [Claude Code](https://claude.com/claude-code)