### PR TITLE
[Phase 1] CI/CD 파이프라인 전면 재설계 — 4단계 CI Gate + 5단계 CD 체인

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,103 +3,364 @@ name: CD
 # ─────────────────────────────────────────────────────────
 # 트리거: CI 워크플로우 완료 후 자동 실행 (main 브랜치 한정)
 #
-# 교육적 관점 (DevOps):
-# 별도 파일의 워크플로우 간에는 needs:를 사용할 수 없다.
-# workflow_run 이벤트로 "CI가 성공한 경우에만" CD를 실행한다.
+# 파이프라인 구조 (5단계 직렬 배포 체인):
+#
+#   [docker-build-push]
+#         ↓
+#   [container-scan]
+#         ↓
+#       [e2e]           ← Actions 러너에서 서버 자동 기동 후 테스트
+#         ↓
+#   [pages-deploy]
+#         ↓
+#   [smoke-test]
+#
+# 교육적 관점 (지속적 배포, Continuous Delivery):
+# 별도 스테이징 서버 없이 Actions 러너 내에서 Docker 이미지를 검증하고
+# GitHub Pages 로 정적 배포까지 자동화한다.
+# 비유: 공장 품질검사(CI) → 창고 입고(Registry) → 보안 검수(Container Scan)
+#       → 현장 시험 운행(E2E) → 공개 출하(Pages)
 # ─────────────────────────────────────────────────────────
 on:
   workflow_run:
-    workflows: ["CI"]   # ci.yml의 name: CI 와 정확히 일치
+    workflows: ["CI"]
     types: [completed]
     branches: [main]
 
 jobs:
-  # ─────────────────────────────────────────────────────────
-  # Job 1: E2E 테스트 (Playwright)
-  # AC: CI 성공 시에만 실행 / Headless 모드 통과
-  # ─────────────────────────────────────────────────────────
-  e2e:
-    name: E2E Tests (Playwright)
+  # ═══════════════════════════════════════════════════════
+  # Job 1: Docker 이미지 빌드 및 GHCR 푸시 (불변 이미지 생성)
+  #
+  # SHA 태그(sha-{GITHUB_SHA}): 동일 커밋은 항상 동일 이미지를 보장 (불변성).
+  # latest 태그: 가장 최근 성공 빌드를 가리키는 포인터.
+  # GHA 캐시(type=gha): 레이어 변경이 없으면 재빌드를 생략하여 빌드 시간을 단축한다.
+  # GITHUB_TOKEN: GitHub 이 자동 제공하므로 별도 시크릿 등록이 불필요하다.
+  # ═══════════════════════════════════════════════════════
+  docker-build-push:
+    name: Docker Build and Push to GHCR
     runs-on: ubuntu-latest
-    # AC: CI 실패 시 CD가 실행되지 않아야 함
+    # CI 파이프라인이 실패한 경우 CD 전체를 차단하는 Guard Condition
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      packages: write
 
     steps:
-      - name: Checkout code
+      - name: 소스 코드 체크아웃
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 20.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-
-      - name: Install backend dependencies
-        run: npm ci
-        working-directory: backend
-
-      - name: Install frontend dependencies
-        run: npm ci
-        working-directory: frontend
-
-      - name: Install Playwright dependencies
-        run: npm ci
-        working-directory: e2e
-
-      - name: Install Playwright browsers (Chromium only)
-        run: npx playwright install chromium --with-deps
-        working-directory: e2e
-
-      # AC: Playwright 테스트가 Headless 모드로 통과하는가?
-      - name: Run E2E tests
-        run: npm test
-        working-directory: e2e
-        env:
-          CI: true
-
-      # AC: 실패한 E2E 리포트가 Artifact로 업로드되는가?
-      - name: Upload Playwright report on failure
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: playwright-report
-          path: e2e/playwright-report/
-          retention-days: 7
-
-  # ─────────────────────────────────────────────────────────
-  # Job 2: Docker 이미지 빌드 검증
-  # AC: e2e → docker 순서로 직렬 실행
-  # ─────────────────────────────────────────────────────────
-  docker:
-    name: Docker Build
-    runs-on: ubuntu-latest
-    # AC: e2e → docker 순서로 직렬 실행되는가?
-    needs: [e2e]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
+      # Docker Buildx: 멀티플랫폼 빌드 및 고급 레이어 캐싱을 지원하는 빌더
+      - name: Docker Buildx 설정
         uses: docker/setup-buildx-action@v3
 
-      # AC: Docker 이미지가 오류 없이 빌드되는가? (frontend)
-      - name: Build frontend Docker image
+      # GITHUB_TOKEN 으로 GHCR 인증 — 외부 레지스트리 자격증명 불필요
+      - name: GHCR 로그인 (GitHub Container Registry)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Frontend 이미지 빌드 및 푸시
+      # context: 루트(.) — nginx.conf 가 저장소 루트에 위치하므로 필수
+      # cache scope=frontend: 백엔드와 독립적으로 레이어 캐시를 관리한다
+      - name: Frontend Docker 이미지 빌드 및 GHCR 푸시
         uses: docker/build-push-action@v6
         with:
           context: .
           file: frontend/Dockerfile
-          push: false
-          tags: card-match-game/frontend:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/card-match-game/frontend:sha-${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/card-match-game/frontend:latest
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
 
-      # AC: Docker 이미지가 오류 없이 빌드되는가? (backend)
-      - name: Build backend Docker image
+      # Backend 이미지 빌드 및 푸시
+      # context: ./backend — Dockerfile 이 backend/ 내부 파일만 참조하므로 컨텍스트를 최소화한다
+      - name: Backend Docker 이미지 빌드 및 GHCR 푸시
         uses: docker/build-push-action@v6
         with:
           context: ./backend
           file: backend/Dockerfile
-          push: false
-          tags: card-match-game/backend:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/card-match-game/backend:sha-${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/card-match-game/backend:latest
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
+
+      # ── 결과 가시성: GitHub Step Summary 출력 ────────────
+      - name: Docker 빌드 및 푸시 결과 요약 출력
+        if: always()
+        run: |
+          echo "## Docker 이미지 빌드 및 GHCR 푸시 결과" >> $GITHUB_STEP_SUMMARY
+          echo "| 이미지 | 태그 | 상태 |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend | sha-${{ github.sha }}, latest | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend | sha-${{ github.sha }}, latest | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Registry: ghcr.io/${{ github.repository_owner }}/card-match-game" >> $GITHUB_STEP_SUMMARY
+
+  # ═══════════════════════════════════════════════════════
+  # Job 2: 컨테이너 이미지 보안 스캔 (Trivy)
+  #
+  # CI 의 파일시스템 스캔과 다르게, 이미지 스캔은 Alpine OS 레이어와
+  # 멀티 스테이지 빌드 결과물 전체를 검사하여 추가 취약점을 탐지한다.
+  # CRITICAL 취약점 발견 시 이후 배포 단계를 즉시 차단하여 오염을 방지한다.
+  # ═══════════════════════════════════════════════════════
+  container-scan:
+    name: Container Security Scan (Trivy)
+    runs-on: ubuntu-latest
+    needs: [docker-build-push]
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: 소스 코드 체크아웃
+        uses: actions/checkout@v4
+
+      # Trivy 가 GHCR 의 프라이빗 이미지를 풀하기 위해 로그인이 필요하다
+      - name: GHCR 로그인
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Frontend 이미지 스캔
+      # exit-code: 1 — CRITICAL 취약점 발견 시 파이프라인 즉시 중단
+      # ignore-unfixed: true — 패치 없는 취약점 제외 (false positive 감소)
+      - name: Frontend 컨테이너 이미지 보안 스캔
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'ghcr.io/${{ github.repository_owner }}/card-match-game/frontend:sha-${{ github.sha }}'
+          format: 'table'
+          severity: 'CRITICAL'
+          exit-code: '1'
+          ignore-unfixed: true
+
+      # Backend 이미지 스캔
+      - name: Backend 컨테이너 이미지 보안 스캔
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'ghcr.io/${{ github.repository_owner }}/card-match-game/backend:sha-${{ github.sha }}'
+          format: 'table'
+          severity: 'CRITICAL'
+          exit-code: '1'
+          ignore-unfixed: true
+
+      # ── 결과 가시성: GitHub Step Summary 출력 ────────────
+      - name: 컨테이너 스캔 결과 요약 출력
+        if: always()
+        run: |
+          echo "## 컨테이너 보안 스캔 결과 (Trivy)" >> $GITHUB_STEP_SUMMARY
+          echo "| 이미지 | 기준 | 상태 |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend (sha-${{ github.sha }}) | CRITICAL | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend (sha-${{ github.sha }}) | CRITICAL | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+
+  # ═══════════════════════════════════════════════════════
+  # Job 3: E2E 테스트 (Playwright — Actions 러너 내 서버 자동 기동)
+  #
+  # 별도 스테이징 서버 없이 Actions 러너에서 직접 서버를 기동하여 E2E 를 수행한다.
+  # playwright.config.ts 의 webServer 설정이 자동으로:
+  #   1. backend: npm run dev (port 3001)
+  #   2. frontend: npm run build && npm run preview (port 4173)
+  # 를 기동한 후 테스트를 실행하고, 완료 시 서버를 종료한다.
+  #
+  # 교육적 관점 (Self-Contained Test):
+  # PLAYWRIGHT_BASE_URL 을 설정하지 않으면 webServer 가 활성화되어
+  # 외부 의존성 없이 완전히 독립적인 E2E 환경이 구성된다.
+  # 비유: 공장 시험실에서 제품을 완전히 조립한 뒤 자체 검사하는 것과 같다.
+  # ═══════════════════════════════════════════════════════
+  e2e:
+    name: E2E Tests (Playwright — Self-Contained)
+    runs-on: ubuntu-latest
+    needs: [container-scan]
+
+    steps:
+      - name: 소스 코드 체크아웃
+        uses: actions/checkout@v4
+
+      # ── Backend 의존성 설치 (webServer 기동에 필요) ───────
+      - name: Node.js 설정 — Backend (npm 캐시 활성화)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Backend 의존성 설치
+        run: npm ci
+        working-directory: backend
+
+      # ── Frontend 의존성 설치 (webServer 기동에 필요) ──────
+      - name: Node.js 설정 — Frontend (npm 캐시 활성화)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Frontend 의존성 설치
+        run: npm ci
+        working-directory: frontend
+
+      # ── E2E 의존성 설치 ───────────────────────────────────
+      - name: Node.js 설정 — E2E (npm 캐시 활성화)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: E2E 의존성 설치
+        run: npm ci
+        working-directory: e2e
+
+      # CI 시간 최소화를 위해 Chromium 단일 브라우저만 설치한다
+      - name: Playwright Chromium 브라우저 설치
+        run: npx playwright install chromium --with-deps
+        working-directory: e2e
+
+      # PLAYWRIGHT_BASE_URL 미설정 → playwright.config.ts 의 webServer 가 자동 활성화된다
+      # CI: true → workers: 1 (직렬 실행), reuseExistingServer: false (항상 신규 기동)
+      - name: E2E 테스트 실행 (백엔드 + 프론트엔드 자동 기동)
+        run: npx playwright test
+        working-directory: e2e
+        env:
+          CI: true
+
+      # 테스트 실패 시 HTML 리포트를 7일간 보관하여 원인 분석에 활용한다
+      - name: 실패 시 Playwright 리포트 Artifact 업로드
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report-${{ github.sha }}
+          path: e2e/playwright-report/
+          retention-days: 7
+
+      # ── 결과 가시성: GitHub Step Summary 출력 ────────────
+      - name: E2E 테스트 결과 요약 출력
+        if: always()
+        run: |
+          echo "## E2E 테스트 결과 (Self-Contained)" >> $GITHUB_STEP_SUMMARY
+          echo "| 항목 | 값 |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| 테스트 환경 | Actions 러너 내 로컬 서버 (webServer 자동 기동) |" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend | http://localhost:3001 |" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend | http://localhost:4173 |" >> $GITHUB_STEP_SUMMARY
+          echo "| 커밋 SHA | ${{ github.sha }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 테스트 상태 | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+
+  # ═══════════════════════════════════════════════════════
+  # Job 4: GitHub Pages 정적 배포
+  #
+  # E2E 테스트 통과 후 프론트엔드 빌드 산출물을 GitHub Pages 에 공개한다.
+  # configure-pages: 프로젝트 페이지의 base_path 를 동적으로 획득한다.
+  # --base 옵션: Vite 빌드 시 올바른 경로 prefix 를 적용한다.
+  # environment.url: Actions 인터페이스에서 배포 URL 링크가 자동으로 표시된다.
+  #
+  # 사전 조건: 저장소 Settings > Pages > Source 를 GitHub Actions 로 설정해야 한다.
+  # ═══════════════════════════════════════════════════════
+  pages-deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: [e2e]
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: 소스 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Node.js 설정 — Frontend (npm 캐시 활성화)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Frontend 의존성 설치
+        run: npm ci
+        working-directory: frontend
+
+      # base_path: 프로젝트 페이지 경로를 동적으로 획득한다 (예: /card-match-game/)
+      - name: GitHub Pages 설정 및 base_path 획득
+        uses: actions/configure-pages@v5
+        id: pages
+
+      # TypeScript 컴파일 후 Vite 빌드 시 base_path 적용
+      # 이렇게 해야 asset 경로(JS, CSS, 이미지)가 Pages URL 기준으로 올바르게 생성된다
+      - name: Frontend 프로덕션 빌드 (GitHub Pages base 경로 적용)
+        run: npx tsc -b && npx vite build --base="${{ steps.pages.outputs.base_path }}"
+        working-directory: frontend
+
+      # frontend/dist 디렉토리를 Pages 배포용 Artifact 로 패키징한다
+      - name: GitHub Pages Artifact 업로드 (frontend/dist)
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend/dist
+
+      # 업로드된 Artifact 를 GitHub Pages 에 배포한다
+      - name: GitHub Pages 배포
+        uses: actions/deploy-pages@v4
+        id: deployment
+
+      # ── 결과 가시성: GitHub Step Summary 출력 ────────────
+      - name: GitHub Pages 배포 결과 요약 출력
+        if: always()
+        run: |
+          echo "## GitHub Pages 배포 결과" >> $GITHUB_STEP_SUMMARY
+          echo "| 항목 | 값 |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| 배포 URL | ${{ steps.deployment.outputs.page_url }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 커밋 SHA | ${{ github.sha }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 배포 상태 | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+
+  # ═══════════════════════════════════════════════════════
+  # Job 5: GitHub Pages Smoke Test (사이트 생존 여부 확인)
+  #
+  # 배포 직후 CDN 전파 지연을 고려하여 최대 5회, 10초 간격으로 재시도한다.
+  # curl -sSf: HTTP 200 이외의 응답은 오류로 처리하여 파이프라인을 실패시킨다.
+  # 비유: 음식 배달 후 고객이 수령 여부를 전화로 확인하는 것과 같다.
+  # ═══════════════════════════════════════════════════════
+  smoke-test:
+    name: Smoke Test (GitHub Pages 생존 확인)
+    runs-on: ubuntu-latest
+    needs: [pages-deploy]
+
+    steps:
+      # CDN 전파 완료를 위해 재시도 로직으로 접속을 확인한다
+      - name: GitHub Pages 사이트 생존 여부 확인 (curl Smoke Test)
+        run: |
+          PAGE_URL="${{ needs.pages-deploy.outputs.page_url }}"
+          echo "Smoke Test 대상 URL: $PAGE_URL"
+          curl -sSf \
+            --retry 5 \
+            --retry-delay 10 \
+            --retry-connrefused \
+            --max-time 30 \
+            "$PAGE_URL"
+          echo "Smoke Test 통과: $PAGE_URL 에서 HTTP 200 응답 수신"
+
+      # ── 결과 가시성: GitHub Step Summary 출력 ────────────
+      - name: Smoke Test 결과 요약 출력
+        if: always()
+        run: |
+          echo "## Smoke Test 결과" >> $GITHUB_STEP_SUMMARY
+          echo "| 항목 | 값 |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| 검증 URL | ${{ needs.pages-deploy.outputs.page_url }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 재시도 횟수 | 최대 5회 (10초 간격) |" >> $GITHUB_STEP_SUMMARY
+          echo "| 최종 상태 | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,19 @@
 name: CI
 
+# ─────────────────────────────────────────────────────────
+# 트리거: main/develop 브랜치 Push 또는 PR 생성 시 즉시 실행
+#
+# 파이프라인 구조 (다이아몬드 CI Gate):
+#
+#   [static-analysis] ─┐
+#                      ├──> [unit-test]
+#   [security-scan]   ─┤
+#                      └──> [integration-test]
+#
+# Stage 1이 모두 통과해야 Stage 2가 실행된다 (Fail Fast 원칙).
+# 비유: 자동차 공장에서 도면 검토(정적 분석)와 재료 검사(보안 스캔)를
+#       모두 통과한 경우에만 조립 테스트(유닛/통합)를 시작하는 것과 같다.
+# ─────────────────────────────────────────────────────────
 on:
   push:
     branches: [main, develop]
@@ -7,85 +21,253 @@ on:
     branches: [main, develop]
 
 jobs:
-  # ─────────────────────────────────────────────────────────
-  # Job 1: Frontend CI (React + Vite + TypeScript)
-  # ─────────────────────────────────────────────────────────
-  frontend-ci:
-    name: Frontend CI (React + Vite)
+  # ═══════════════════════════════════════════════════════
+  # STAGE 1-A: 정적 분석 (ESLint + TypeScript 타입 체크)
+  #
+  # 코드 품질과 타입 오류를 가장 빠르게 감지하는 첫 번째 관문이다.
+  # Fail Fast 원칙: 컴파일 오류나 린트 위반은 테스트보다 수십 배 빠르게 발견할 수 있다.
+  # 비유: 건물 설계도를 시공 전에 검토하여 오류를 잡는 것과 같다.
+  # ═══════════════════════════════════════════════════════
+  static-analysis:
+    name: Static Analysis (ESLint + TypeScript)
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
 
     steps:
-      - name: Checkout code
+      - name: 소스 코드 체크아웃
         uses: actions/checkout@v4
 
-      - name: Setup Node.js 20.x
+      # ── Frontend 정적 분석 ────────────────────────────────
+      - name: Node.js 설정 — Frontend (npm 캐시 활성화)
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
-      - name: Install dependencies
+      - name: Frontend 의존성 설치
         run: npm ci
+        working-directory: frontend
 
-      - name: ESLint 정적 분석
+      - name: Frontend ESLint 정적 분석
         run: npm run lint
+        working-directory: frontend
 
-      - name: TypeScript 타입 체크
+      - name: Frontend TypeScript 타입 체크
         run: npm run typecheck
+        working-directory: frontend
 
-      - name: Run unit tests (Vitest)
-        run: npm test
-
-      - name: Build
-        run: npm run build
-
-  # ─────────────────────────────────────────────────────────
-  # Job 2: Backend CI (Express + TypeScript)
-  # ─────────────────────────────────────────────────────────
-  backend-ci:
-    name: Backend CI (Express + TypeScript)
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js 20.x
+      # ── Backend 정적 분석 ─────────────────────────────────
+      - name: Node.js 설정 — Backend (npm 캐시 활성화)
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: 'npm'
           cache-dependency-path: backend/package-lock.json
 
-      - name: Install dependencies
+      - name: Backend 의존성 설치
         run: npm ci
+        working-directory: backend
 
-      - name: TypeScript 타입 체크
-        run: npm run typecheck
-
-      - name: ESLint 정적 분석
+      - name: Backend ESLint 정적 분석
         run: npm run lint
+        working-directory: backend
 
-      # ── 단위 테스트: 외부 의존성 없이 순수 로직만 격리 검증 ──────────
-      # 비유: 자동차 부품(엔진, 변속기)을 조립 전에 개별 성능 검사
-      - name: Unit Tests (utils, controllers — mock 격리)
+      - name: Backend TypeScript 타입 체크
+        run: npm run typecheck
+        working-directory: backend
+
+      # ── 결과 가시성: GitHub Step Summary 출력 ────────────
+      - name: 정적 분석 결과 요약 출력
+        if: always()
+        run: |
+          echo "## 정적 분석 결과" >> $GITHUB_STEP_SUMMARY
+          echo "| 항목 | 상태 |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend ESLint | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend TypeScript | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend ESLint | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend TypeScript | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+
+  # ═══════════════════════════════════════════════════════
+  # STAGE 1-B: 보안 스캔 (npm audit + Trivy 파일시스템 스캔)
+  #
+  # 소스 코드 및 의존성의 알려진 취약점(CVE)을 탐지하는 두 번째 관문이다.
+  # Supply Chain Security: 오픈소스 의존성은 "신뢰하되 검증하라" 원칙을 적용한다.
+  # npm audit: 등록된 CVE가 있는 패키지를 탐지한다.
+  # Trivy: 소스 코드, 설정 파일, 하드코딩된 시크릿을 탐지한다.
+  # ═══════════════════════════════════════════════════════
+  security-scan:
+    name: Security Scan (npm audit + Trivy)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 소스 코드 체크아웃
+        uses: actions/checkout@v4
+
+      # ── Frontend 의존성 취약점 스캔 ───────────────────────
+      - name: Node.js 설정 — Frontend (npm 캐시 활성화)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Frontend 의존성 설치
+        run: npm ci
+        working-directory: frontend
+
+      # audit-level=high: HIGH 이상 심각도만 빌드 실패 처리 (moderate 이하는 경고)
+      - name: Frontend 의존성 취약점 스캔 (npm audit)
+        run: npm audit --audit-level=high
+        working-directory: frontend
+
+      # ── Backend 의존성 취약점 스캔 ────────────────────────
+      - name: Node.js 설정 — Backend (npm 캐시 활성화)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Backend 의존성 설치
+        run: npm ci
+        working-directory: backend
+
+      - name: Backend 의존성 취약점 스캔 (npm audit)
+        run: npm audit --audit-level=high
+        working-directory: backend
+
+      # ── Trivy 파일시스템 스캔 ─────────────────────────────
+      # scan-type: fs — 소스 코드, 설정 파일, IaC 전체를 스캔한다.
+      # ignore-unfixed: true — 패치가 없는 취약점은 제외하여 false positive를 감소시킨다.
+      - name: Trivy 소스 코드 및 설정 파일 보안 스캔
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          severity: 'HIGH,CRITICAL'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+
+      # ── 결과 가시성: GitHub Step Summary 출력 ────────────
+      - name: 보안 스캔 결과 요약 출력
+        if: always()
+        run: |
+          echo "## 보안 스캔 결과" >> $GITHUB_STEP_SUMMARY
+          echo "| 스캔 항목 | 기준 | 상태 |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend npm audit | HIGH,CRITICAL | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend npm audit | HIGH,CRITICAL | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Trivy 파일시스템 스캔 | HIGH,CRITICAL | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+
+  # ═══════════════════════════════════════════════════════
+  # STAGE 2-A: 단위 테스트 (Frontend Vitest + Backend Jest unit)
+  #
+  # CI Gate: static-analysis 와 security-scan 이 모두 성공해야 실행된다.
+  #
+  # 단위 테스트는 외부 의존성 없이 순수 비즈니스 로직만 격리하여 검증한다.
+  # 비유: 자동차 부품(엔진, 변속기)을 조립 전에 개별 성능 검사하는 것과 같다.
+  # ═══════════════════════════════════════════════════════
+  unit-test:
+    name: Unit Tests (Frontend Vitest + Backend Jest)
+    runs-on: ubuntu-latest
+    needs: [static-analysis, security-scan]
+
+    steps:
+      - name: 소스 코드 체크아웃
+        uses: actions/checkout@v4
+
+      # ── Frontend 단위 테스트 (Vitest) ─────────────────────
+      - name: Node.js 설정 — Frontend (npm 캐시 활성화)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Frontend 의존성 설치
+        run: npm ci
+        working-directory: frontend
+
+      # 대상: frontend/src/__tests__/Card.test.tsx, gameReducer.test.ts
+      - name: Frontend 단위 테스트 실행 (Vitest)
+        run: npm test
+        working-directory: frontend
+
+      # ── Backend 단위 테스트 (Jest — unit 디렉토리만) ───────
+      - name: Node.js 설정 — Backend (npm 캐시 활성화)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Backend 의존성 설치
+        run: npm ci
+        working-directory: backend
+
+      # 대상: backend/src/__tests__/unit/ (gameController, generateCards, shuffle)
+      - name: Backend 단위 테스트 실행 (Jest — unit only)
         run: npm run test:unit
+        working-directory: backend
 
-      # ── 통합 테스트: HTTP 레이어 + Express 앱 전체 동작 검증 ─────────
-      # 비유: 완성된 자동차를 트랙에서 실제 주행 테스트
-      - name: Integration Tests (API, middleware — supertest)
+      # ── 결과 가시성: GitHub Step Summary 출력 ────────────
+      - name: 단위 테스트 결과 요약 출력
+        if: always()
+        run: |
+          echo "## 단위 테스트 결과" >> $GITHUB_STEP_SUMMARY
+          echo "| 테스트 스위트 | 상태 |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Frontend Vitest (Card, gameReducer) | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Backend Jest Unit (gameController, generateCards, shuffle) | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+
+  # ═══════════════════════════════════════════════════════
+  # STAGE 2-B: 통합 테스트 + 커버리지 검증 (Backend Jest)
+  #
+  # CI Gate: static-analysis 와 security-scan 이 모두 성공해야 실행된다.
+  #
+  # 통합 테스트는 HTTP 레이어 + Express 앱 전체 동작을 검증한다.
+  # 비유: 완성된 자동차를 실제 트랙에서 주행 테스트하는 것과 같다.
+  # 커버리지 80% 임계값: jest.config.js 에 설정된 임계값 미달 시 빌드 실패.
+  # ═══════════════════════════════════════════════════════
+  integration-test:
+    name: Integration Tests + Coverage (Backend Jest)
+    runs-on: ubuntu-latest
+    needs: [static-analysis, security-scan]
+
+    steps:
+      - name: 소스 코드 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Node.js 설정 — Backend (npm 캐시 활성화)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Backend 의존성 설치
+        run: npm ci
+        working-directory: backend
+
+      # 대상: backend/src/__tests__/integration/ (gameApi, errorHandler)
+      - name: Backend 통합 테스트 실행 (Jest — integration only)
         run: npm run test:integration
+        working-directory: backend
 
-      # ── 전체 커버리지: 80% 임계값 미달 시 빌드 실패 ──────────────────
-      - name: Coverage check (threshold 80% — all tests)
+      # jest.config.js 의 coverageThreshold (branches/functions/lines/statements 80%)
+      # 임계값 미달 시 exit code 1 반환 → 빌드 실패
+      - name: 전체 커버리지 검증 (임계값 80%)
         run: npm run test:coverage
+        working-directory: backend
 
-      - name: Build
-        run: npm run build
+      # ── 결과 가시성: GitHub Step Summary 출력 ────────────
+      - name: 통합 테스트 및 커버리지 결과 요약 출력
+        if: always()
+        run: |
+          echo "## 통합 테스트 + 커버리지 결과" >> $GITHUB_STEP_SUMMARY
+          echo "| 항목 | 상태 |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| 통합 테스트 (gameApi, errorHandler) | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 커버리지 임계값 검증 (전체 80%) | ${{ job.status }} |" >> $GITHUB_STEP_SUMMARY

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,16 +3,26 @@ import { defineConfig, devices } from '@playwright/test'
 /**
  * Playwright E2E 설정
  *
- * webServer 2개 자동 기동:
- *  1. backend: Express (port 3001)
- *  2. frontend: Vite preview (port 4173) — 빌드 후 정적 파일 서빙
+ * 실행 환경별 동작 분기:
  *
- * 교육적 관점 (Testing Strategy):
- * E2E 테스트는 실제 브라우저 + 실서버 조합으로 "사용자 시나리오"를 검증한다.
- * webServer.reuseExistingServer=!CI 설정으로,
- *   - 로컬: 이미 띄워진 서버 재사용 (개발 편의성)
- *   - CI: 항상 새 서버 기동 (결정론적 환경 보장)
+ *  1. 로컬 개발 환경 (PLAYWRIGHT_BASE_URL 미설정):
+ *     - baseURL: http://localhost:4173
+ *     - webServer: backend(3001) + frontend(4173) 자동 기동
+ *     - reuseExistingServer: true (이미 실행 중인 서버 재사용)
+ *
+ *  2. CD 파이프라인 스테이징 환경 (PLAYWRIGHT_BASE_URL 설정됨):
+ *     - baseURL: PLAYWRIGHT_BASE_URL (스테이징 서버 URL)
+ *     - webServer: 생략 (스테이징 서버가 이미 실행 중이므로 불필요)
+ *
+ * 교육적 관점 (환경 분리 원칙):
+ * 테스트 환경 전환 시 코드 수정 없이 환경변수만으로 동작을 변경한다.
+ * 비유: 영업사원이 같은 프레젠테이션을 국내/해외 고객에게 언어만 바꿔 사용하는 것과 같다.
  */
+
+// PLAYWRIGHT_BASE_URL 이 설정된 경우 스테이징 환경으로 판단한다
+const isStaging = !!process.env.PLAYWRIGHT_BASE_URL
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:4173'
+
 export default defineConfig({
   testDir: './tests',
   timeout: 30_000,
@@ -22,8 +32,8 @@ export default defineConfig({
   reporter: [['list'], ['html', { open: 'never' }]],
 
   use: {
-    baseURL: 'http://localhost:4173',
-    screenshot: 'only-on-failure',  // AC: 실패 시 스크린샷 저장
+    baseURL,
+    screenshot: 'only-on-failure',
     trace: 'on-first-retry',
   },
 
@@ -34,20 +44,26 @@ export default defineConfig({
     },
   ],
 
-  webServer: [
-    {
-      command: 'npm run dev',
-      cwd: '../backend',
-      port: 3001,
-      reuseExistingServer: !process.env.CI,
-      timeout: 30_000,
-    },
-    {
-      command: 'npm run build && npm run preview',
-      cwd: '../frontend',
-      port: 4173,
-      reuseExistingServer: !process.env.CI,
-      timeout: 60_000,
-    },
-  ],
+  // 스테이징 환경에서는 서버가 이미 실행 중이므로 webServer 기동을 생략한다.
+  // 로컬 환경에서는 기존 방식대로 백엔드와 프론트엔드를 자동으로 기동한다.
+  ...(isStaging
+    ? {}
+    : {
+        webServer: [
+          {
+            command: 'npm run dev',
+            cwd: '../backend',
+            port: 3001,
+            reuseExistingServer: !process.env.CI,
+            timeout: 30_000,
+          },
+          {
+            command: 'npm run build && npm run preview',
+            cwd: '../frontend',
+            port: 4173,
+            reuseExistingServer: !process.env.CI,
+            timeout: 60_000,
+          },
+        ],
+      }),
 })


### PR DESCRIPTION
## Summary

기존 `frontend-ci` / `backend-ci` 단일 잡 구조와 불완전한 CD를 완전히 교체한다.

Closes #108

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `.github/workflows/ci.yml` | Stage 1 병렬(static-analysis, security-scan) + Stage 2 CI Gate(unit-test, integration-test) |
| `.github/workflows/cd.yml` | docker-build-push → container-scan → e2e → pages-deploy → smoke-test 5단계 직렬 |
| `e2e/playwright.config.ts` | PLAYWRIGHT_BASE_URL 환경변수 분기 — webServer 조건부 활성화 |

## CI 파이프라인 구조

```
[static-analysis] ─┐
                   ├──> [unit-test]
[security-scan]   ─┤
                   └──> [integration-test]
```

Stage 1이 하나라도 실패하면 Stage 2 전체가 실행되지 않는다 (Fail Fast).

## CD 파이프라인 구조

```
[docker-build-push] → [container-scan] → [e2e] → [pages-deploy] → [smoke-test]
```

- `docker-build-push`: GHCR SHA 태그 불변 이미지, GHA 레이어 캐시(scope 분리)
- `container-scan`: Trivy 이미지 스캔 CRITICAL 차단, GITHUB_TOKEN 자동 인증
- `e2e`: Self-Contained — webServer가 backend(3001) + frontend(4173) 자동 기동
- `pages-deploy`: configure-pages base_path 동적 획득 → vite build --base 적용
- `smoke-test`: curl --retry 5 --retry-delay 10으로 HTTP 200 검증

## Acceptance Criteria 검증

- [x] 새 CI 잡(static-analysis, security-scan, unit-test, integration-test) 등록
- [x] 새 CD 잡(docker-build-push, container-scan, e2e, pages-deploy, smoke-test) 등록
- [x] 구 잡 이름(frontend-ci, backend-ci, docker) 완전 제거 확인
- [x] YAML 구조 검증 통과
- [x] Backend 단위 테스트 23개 통과
- [x] Frontend 단위 테스트 19개 통과

## Test plan

- [ ] main 브랜치 merge 후 CI Actions 탭에서 다이아몬드 의존성 그래프 확인
- [ ] CD Actions 탭에서 5단계 직렬 체인 확인
- [ ] GitHub Pages 배포 URL 접속 확인
- [ ] Smoke Test HTTP 200 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)