### PR TITLE
fix: GitHub Pages에서 게임 초기화 실패 404 에러 수정

### DIFF
--- a/frontend/src/__tests__/gameApi.test.ts
+++ b/frontend/src/__tests__/gameApi.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import { startGame } from '../api/gameApi'
+
+vi.mock('axios')
+const mockedAxios = vi.mocked(axios, true)
+
+// ─── 정상 응답 ─────────────────────────────────────────────────────────────────
+describe('startGame — 백엔드 정상 응답', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('서버 응답을 Card 배열로 변환하여 반환한다', async () => {
+    const serverCards = Array.from({ length: 16 }, (_, i) => ({
+      id: `server-id-${i}`,
+      type: 'apple',
+      imgUrl: '/images/apple.png',
+    }))
+    mockedAxios.get = vi.fn().mockResolvedValue({
+      data: { gameId: 'server-game-id', cards: serverCards },
+    })
+
+    const { gameId, cards } = await startGame()
+
+    expect(gameId).toBe('server-game-id')
+    expect(cards).toHaveLength(16)
+    // isFlipped / isSolved 초기값 추가 여부 확인
+    expect(cards[0].isFlipped).toBe(false)
+    expect(cards[0].isSolved).toBe(false)
+  })
+})
+
+// ─── 폴백: 404 ────────────────────────────────────────────────────────────────
+describe('startGame — 백엔드 404 (GitHub Pages 환경)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('404 응답 시 로컬에서 16장 카드를 생성하여 반환한다', async () => {
+    const axiosError = Object.assign(new Error('404'), {
+      isAxiosError: true,
+      response: { status: 404 },
+      request: {},
+    })
+    mockedAxios.get = vi.fn().mockRejectedValue(axiosError)
+    mockedAxios.isAxiosError = vi.fn().mockReturnValue(true)
+
+    const { gameId, cards } = await startGame()
+
+    expect(gameId).toBeTruthy()
+    expect(cards).toHaveLength(16)
+    expect(cards[0].isFlipped).toBe(false)
+    expect(cards[0].isSolved).toBe(false)
+  })
+
+  it('폴백 시 8가지 과일이 각 2장씩 포함된다', async () => {
+    const axiosError = Object.assign(new Error('404'), {
+      isAxiosError: true,
+      response: { status: 404 },
+      request: {},
+    })
+    mockedAxios.get = vi.fn().mockRejectedValue(axiosError)
+    mockedAxios.isAxiosError = vi.fn().mockReturnValue(true)
+
+    const { cards } = await startGame()
+
+    const typeCounts: Record<string, number> = {}
+    cards.forEach((card) => {
+      typeCounts[card.type] = (typeCounts[card.type] ?? 0) + 1
+    })
+
+    // 8가지 과일 타입이 존재해야 한다
+    expect(Object.keys(typeCounts)).toHaveLength(8)
+    // 각 타입은 정확히 2장이어야 한다
+    Object.values(typeCounts).forEach((count) => {
+      expect(count).toBe(2)
+    })
+  })
+})
+
+// ─── 폴백: 네트워크 오류 ──────────────────────────────────────────────────────
+describe('startGame — 네트워크 오류 (서버 응답 없음)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('네트워크 오류(응답 없음) 시 로컬 폴백으로 게임을 생성한다', async () => {
+    const networkError = Object.assign(new Error('Network Error'), {
+      isAxiosError: true,
+      response: undefined,
+      request: {},
+    })
+    mockedAxios.get = vi.fn().mockRejectedValue(networkError)
+    mockedAxios.isAxiosError = vi.fn().mockReturnValue(true)
+
+    const { gameId, cards } = await startGame()
+
+    expect(gameId).toBeTruthy()
+    expect(cards).toHaveLength(16)
+  })
+})

--- a/frontend/src/__tests__/gameApi.test.ts
+++ b/frontend/src/__tests__/gameApi.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import axios from 'axios'
+import type { AxiosError } from 'axios'
 import { startGame } from '../api/gameApi'
 
 vi.mock('axios')
 const mockedAxios = vi.mocked(axios, true)
+
+// axios.isAxiosError는 타입 가드(type predicate) 함수이므로
+// mockImplementation으로 타입을 명시하여 TypeScript 오류를 방지한다.
+const mockIsAxiosError = (returnValue: boolean) =>
+  vi.mocked(axios.isAxiosError).mockImplementation(
+    (_err): _err is AxiosError => returnValue,
+  )
 
 // ─── 정상 응답 ─────────────────────────────────────────────────────────────────
 describe('startGame — 백엔드 정상 응답', () => {
@@ -44,7 +52,7 @@ describe('startGame — 백엔드 404 (GitHub Pages 환경)', () => {
       request: {},
     })
     mockedAxios.get = vi.fn().mockRejectedValue(axiosError)
-    mockedAxios.isAxiosError = vi.fn().mockReturnValue(true)
+    mockIsAxiosError(true)
 
     const { gameId, cards } = await startGame()
 
@@ -61,7 +69,7 @@ describe('startGame — 백엔드 404 (GitHub Pages 환경)', () => {
       request: {},
     })
     mockedAxios.get = vi.fn().mockRejectedValue(axiosError)
-    mockedAxios.isAxiosError = vi.fn().mockReturnValue(true)
+    mockIsAxiosError(true)
 
     const { cards } = await startGame()
 
@@ -92,7 +100,7 @@ describe('startGame — 네트워크 오류 (서버 응답 없음)', () => {
       request: {},
     })
     mockedAxios.get = vi.fn().mockRejectedValue(networkError)
-    mockedAxios.isAxiosError = vi.fn().mockReturnValue(true)
+    mockIsAxiosError(true)
 
     const { gameId, cards } = await startGame()
 

--- a/frontend/src/api/gameApi.ts
+++ b/frontend/src/api/gameApi.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Card } from '../types/Card'
+import type { Card, FruitType } from '../types/Card'
 
 /**
  * API Response for /api/game/start
@@ -14,12 +14,45 @@ interface GameStartResponse {
   }>
 }
 
+// 8가지 과일 타입 (백엔드 FRUIT_TYPES와 동일)
+const FRUIT_TYPES: FruitType[] = [
+  'apple', 'banana', 'cherry', 'grape',
+  'lemon', 'orange', 'strawberry', 'watermelon',
+]
+
+// Fisher-Yates 셔플 (백엔드 shuffle.ts와 동일 알고리즘)
+function shuffleArray<T>(array: T[]): T[] {
+  const arr = [...array]
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[arr[i], arr[j]] = [arr[j], arr[i]]
+  }
+  return arr
+}
+
+/**
+ * 클라이언트 사이드 게임 생성 (GitHub Pages 등 백엔드 없는 환경용 폴백)
+ * 백엔드 generateCards() + shuffle() 로직을 브라우저에서 동일하게 실행한다.
+ */
+function generateLocalGame(): { gameId: string; cards: Card[] } {
+  const rawCards = FRUIT_TYPES.flatMap((type) => [
+    { id: crypto.randomUUID(), type, imgUrl: `/images/${type}.png` },
+    { id: crypto.randomUUID(), type, imgUrl: `/images/${type}.png` },
+  ])
+  const cards: Card[] = shuffleArray(rawCards).map((card) => ({
+    ...card,
+    isFlipped: false,
+    isSolved: false,
+  }))
+  return { gameId: crypto.randomUUID(), cards }
+}
+
 /**
  * Start a new game
  * /api/game/start 엔드포인트를 호출하여 새 게임을 시작합니다.
+ * 백엔드를 사용할 수 없는 환경(GitHub Pages 등)에서는 클라이언트 사이드 폴백으로 게임을 생성합니다.
  *
  * @returns Promise<{ gameId: string; cards: Card[] }>
- * @throws Error if API call fails
  *
  * @example
  * const { gameId, cards } = await startGame()
@@ -41,20 +74,16 @@ export async function startGame(): Promise<{ gameId: string; cards: Card[] }> {
       cards,
     }
   } catch (error) {
-    console.error('[API Error] Failed to start game:', error)
-
-    // 에러 메시지를 더 명확하게 전달
-    if (axios.isAxiosError(error)) {
-      if (error.response) {
-        // 서버가 응답을 반환했지만 에러 상태 코드
-        throw new Error(`서버 오류: ${error.response.status}`)
-      } else if (error.request) {
-        // 요청은 보냈지만 응답을 받지 못함
-        throw new Error('서버 연결에 실패했습니다')
-      }
+    // 백엔드를 사용할 수 없는 환경(GitHub Pages, 오프라인 등)에서 클라이언트 사이드로 게임 생성
+    if (
+      axios.isAxiosError(error) &&
+      (error.response?.status === 404 || !error.response)
+    ) {
+      console.warn('[API Fallback] Backend unavailable, generating game locally')
+      return generateLocalGame()
     }
 
-    // 기타 에러
+    console.error('[API Error] Failed to start game:', error)
     throw new Error('게임 시작에 실패했습니다')
   }
 }


### PR DESCRIPTION
## 요약

- Closes #129
- GitHub Pages(정적 호스팅)에서 `/api/game/start` 호출 시 발생하는 404 에러를 클라이언트 사이드 폴백으로 해결

## 변경 내용

### `frontend/src/api/gameApi.ts`

백엔드 API 호출 실패 시 브라우저에서 직접 카드를 생성하는 `generateLocalGame()` 함수를 추가했다.

```
정상 환경:  React → GET /api/game/start → Express 서버 → 카드 배열 반환
폴백 환경:  React → GET /api/game/start → 404 → generateLocalGame() → 게임 시작
```

- 404 응답 또는 네트워크 오류(응답 없음) 발생 시 자동으로 클라이언트 폴백 실행
- `generateLocalGame()`: Fisher-Yates 셔플 + `crypto.randomUUID()` (백엔드 로직과 동일)
- 로컬 개발 / Docker Compose 환경에서 기존 동작(백엔드 API 사용) 유지

### `frontend/src/__tests__/gameApi.test.ts` (신규)

폴백 동작을 검증하는 Vitest 테스트 4개 추가
- 백엔드 정상 응답 시 서버 데이터 반환 확인
- 404 응답 시 16장 카드 로컬 생성 확인
- 폴백 시 8가지 과일 × 2장 구성 확인
- 네트워크 오류 시 로컬 폴백 실행 확인

## 테스트 결과

```
✓ src/__tests__/gameApi.test.ts (4 tests)
✓ src/__tests__/gameReducer.test.ts (14 tests)
✓ src/__tests__/Card.test.tsx (5 tests)
Test Files 3 passed (3) | Tests 23 passed (23)
```

## 소프트웨어 공학적 관점

이 패턴은 **Graceful Degradation(우아한 성능 저하)** 원칙을 적용한 것이다. 서버가 없는 환경에서도 핵심 기능(카드 게임)을 클라이언트 사이드에서 유지함으로써 사용자 경험을 보호한다. 백엔드의 순수 함수(Pure Function)를 프론트엔드에서 재사용할 수 있는 것은 함수형 설계의 장점이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)